### PR TITLE
fix: Stimmgabel 3D-Ansicht, Notenanzeige und A440-Wiedergabe

### DIFF
--- a/lib/features/settings/domain/tuning_pitch_label.dart
+++ b/lib/features/settings/domain/tuning_pitch_label.dart
@@ -18,6 +18,8 @@ const _pitchClassNames = [
   'B',
 ];
 
+const _sharpPitchClasses = {1, 3, 6, 8, 10};
+
 /// Ergebnis der Frequenz-zu-Noten-Anzeige inkl. Stimmungsabweichung.
 class TuningPitchLabel {
   const TuningPitchLabel({
@@ -34,10 +36,46 @@ class TuningPitchLabel {
 
   String get noteWithOctave => '$noteName$octave';
 
-  /// Nur der Tonbuchstabe ohne Oktavzahl, z. B. „a“ statt „A4“.
-  String get noteLetter => noteName.toLowerCase();
+  /// Nur der natürliche Tonbuchstabe ohne Vorzeichen, z. B. „a“.
+  String get noteLetter => naturalNoteLetter;
+
+  /// Natürlicher Buchstabe der gestimmten Note (ohne ♯/♭).
+  String get naturalNoteLetter {
+    final pitchClass = _pitchClassNames.indexOf(noteName);
+    if (pitchClass < 0) {
+      return noteName.substring(0, 1).toLowerCase();
+    }
+    return _naturalNoteLetterForPitchClass(pitchClass);
+  }
+
+  /// Vorzeichen der gestimmten Note (♯), nicht die Abweichung vom Zielton.
+  String? get noteAccidental {
+    final pitchClass = _pitchClassNames.indexOf(noteName);
+    if (pitchClass < 0 || !_sharpPitchClasses.contains(pitchClass)) {
+      return null;
+    }
+    return '♯';
+  }
 
   bool get hasTuningSymbol => tuningSymbol != null;
+}
+
+String _naturalNoteLetterForPitchClass(int pitchClass) {
+  return switch (pitchClass) {
+    0 => 'c',
+    1 => 'c',
+    2 => 'd',
+    3 => 'd',
+    4 => 'e',
+    5 => 'f',
+    6 => 'f',
+    7 => 'g',
+    8 => 'g',
+    9 => 'a',
+    10 => 'a',
+    11 => 'b',
+    _ => 'c',
+  };
 }
 
 /// MIDI-Float (69 = A4) für eine Frequenz in Hz.
@@ -70,11 +108,15 @@ TuningPitchLabel tuningPitchLabelForFrequency(
   final referenceHz = tuningTemperedFrequencyHzForMidi(midiNearest);
   final cents = 1200 * (math.log(frequencyHz / referenceHz) / math.ln2);
 
+  // Bei gerundeter Anzeige nur die gestimmte Note zeigen – keine zusätzlichen
+  // Vorzeichen, die sonst zu doppelten ♯/♭ (z. B. „a♯♯“) führen würden.
   String? tuningSymbol;
-  if (cents > symbolThresholdCents) {
-    tuningSymbol = '♯';
-  } else if (cents < -symbolThresholdCents) {
-    tuningSymbol = '♭';
+  if (!displayTemperedFrequency) {
+    if (cents > symbolThresholdCents) {
+      tuningSymbol = '♯';
+    } else if (cents < -symbolThresholdCents) {
+      tuningSymbol = '♭';
+    }
   }
 
   final displayHz = displayTemperedFrequency

--- a/lib/features/settings/presentation/pages/settings_tuning_fork_page.dart
+++ b/lib/features/settings/presentation/pages/settings_tuning_fork_page.dart
@@ -75,12 +75,16 @@ class _SettingsTuningForkPageState extends State<SettingsTuningForkPage>
     if (_isPlayingReference) return;
 
     HapticFeedback.mediumImpact();
-    await _tapAnimationController.forward();
-    await _tapAnimationController.reverse();
+    unawaited(_tapAnimationController.forward().then((_) {
+      if (mounted) {
+        unawaited(_tapAnimationController.reverse());
+      }
+    }));
 
     await _pitchDetector.stop();
     _frequencySubscription?.cancel();
     _frequencySubscription = null;
+    _pitchStabilizer.reset();
 
     if (!mounted) return;
     setState(() {
@@ -239,6 +243,8 @@ class _FrequencyDisplay extends StatelessWidget {
         Text('${pitchLabel!.frequencyHz} Hz', style: baseStyle),
         const SizedBox(width: 14),
         Text(pitchLabel!.noteLetter, style: noteStyle),
+        if (pitchLabel!.noteAccidental != null)
+          Text(pitchLabel!.noteAccidental!, style: symbolStyle),
         if (pitchLabel!.tuningSymbol != null)
           Text(pitchLabel!.tuningSymbol!, style: symbolStyle),
       ],

--- a/lib/features/settings/presentation/services/tuning_pitch_detector.dart
+++ b/lib/features/settings/presentation/services/tuning_pitch_detector.dart
@@ -26,6 +26,7 @@ class TuningPitchDetector {
   StreamSubscription<Uint8List>? _recordSubscription;
   final List<double> _recentFrequencies = [];
   bool _isRunning = false;
+  bool _isProcessingSample = false;
 
   Stream<double?> get frequencyStream => _frequencyController.stream;
 
@@ -83,19 +84,25 @@ class TuningPitchDetector {
   }
 
   Future<void> _processSample(Uint8List sample) async {
-    final floatBuffer = _pcm16LeToFloat(sample);
-    final result = await _pitchDetector.getPitchFromFloatBuffer(floatBuffer);
-    if (!result.pitched || result.pitch <= 0) {
-      return;
-    }
+    if (_isProcessingSample) return;
+    _isProcessingSample = true;
+    try {
+      final floatBuffer = _pcm16LeToFloat(sample);
+      final result = await _pitchDetector.getPitchFromFloatBuffer(floatBuffer);
+      if (!result.pitched || result.pitch <= 0) {
+        return;
+      }
 
-    _recentFrequencies.add(result.pitch);
-    if (_recentFrequencies.length > _smoothingWindow) {
-      _recentFrequencies.removeAt(0);
-    }
+      _recentFrequencies.add(result.pitch);
+      if (_recentFrequencies.length > _smoothingWindow) {
+        _recentFrequencies.removeAt(0);
+      }
 
-    final median = _median(_recentFrequencies);
-    _frequencyController.add(median);
+      final median = _median(_recentFrequencies);
+      _frequencyController.add(median);
+    } finally {
+      _isProcessingSample = false;
+    }
   }
 
   static double _median(List<double> values) {

--- a/lib/features/settings/presentation/services/tuning_reference_tone_player.dart
+++ b/lib/features/settings/presentation/services/tuning_reference_tone_player.dart
@@ -21,6 +21,7 @@ class TuningReferenceTonePlayer {
     await TuningAudioSession.ensureConfigured();
     await _player.setReleaseMode(ReleaseMode.stop);
     await _player.setVolume(1);
+    await _player.setSource(AssetSource(assetPath));
 
     var completed = false;
     void completeOnce() {
@@ -37,7 +38,7 @@ class TuningReferenceTonePlayer {
 
     _fallbackTimer = Timer(_fallbackDuration, completeOnce);
 
-    await _player.play(AssetSource(assetPath));
+    await _player.resume();
   }
 
   Future<void> stop() async {

--- a/lib/features/settings/presentation/widgets/tuning_fork_model.dart
+++ b/lib/features/settings/presentation/widgets/tuning_fork_model.dart
@@ -18,6 +18,14 @@ class TuningForkModel extends StatefulWidget {
 class _TuningForkModelState extends State<TuningForkModel> {
   static const _modelAsset = 'assets/models/tuning_fork.glb';
 
+  /// Bounding-Box-Mitte des GLB-Modells (Y: −0.96 … 1.40).
+  static const _modelCenterY = 0.22;
+
+  /// model-viewer nutzt den Radius als Prozentwert (105 % = Standard-Framing).
+  static const _cameraOrbitTheta = 28.0;
+  static const _cameraOrbitPhi = 78.0;
+  static const _cameraOrbitRadiusPercent = 115.0;
+
   final Flutter3DController _controller = Flutter3DController();
   bool _isModelReady = false;
 
@@ -40,8 +48,12 @@ class _TuningForkModelState extends State<TuningForkModel> {
 
     setState(() => _isModelReady = true);
     _controller
-      ..setCameraOrbit(22, 74, 2.35)
-      ..setCameraTarget(0, 0.12, 0);
+      ..setCameraTarget(0, _modelCenterY, 0)
+      ..setCameraOrbit(
+        _cameraOrbitTheta,
+        _cameraOrbitPhi,
+        _cameraOrbitRadiusPercent,
+      );
     _syncResonance();
   }
 
@@ -49,7 +61,7 @@ class _TuningForkModelState extends State<TuningForkModel> {
     if (!_isModelReady) return;
 
     if (widget.isResonating) {
-      _controller.startRotation(rotationSpeed: 42);
+      _controller.startRotation(rotationSpeed: 14);
     } else {
       _controller.stopRotation();
     }

--- a/test/features/settings/tuning_pitch_label_test.dart
+++ b/test/features/settings/tuning_pitch_label_test.dart
@@ -27,6 +27,20 @@ void main() {
       final label = tuningPitchLabelForFrequency(440);
       expect(label.noteWithOctave, 'A4');
       expect(label.noteLetter, 'a');
+      expect(label.noteAccidental, isNull);
+      expect(label.tuningSymbol, isNull);
+    });
+
+    test('shows note accidental without duplicate tuning symbol when rounded', () {
+      final label = tuningPitchLabelForFrequency(
+        470,
+        lockedMidiNote: 70,
+        displayTemperedFrequency: true,
+      );
+      expect(label.frequencyHz, 466);
+      expect(label.noteWithOctave, 'A♯4');
+      expect(label.noteLetter, 'a');
+      expect(label.noteAccidental, '♯');
       expect(label.tuningSymbol, isNull);
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Die Stimmgabel-Seite hatte drei sichtbare Probleme:

1. **3D-Modell** wirkte stark verzerrt bzw. stark hereingezoomt – die Stimmgabel war nicht vollständig sichtbar.
2. **Notenanzeige** zeigte beim Singen doppelte Vorzeichen (z. B. `a♯♯`) oder uneinheitliche Darstellung.
3. **A440-Referenzton** startete beim Tippen nicht zuverlässig bzw. spürbar verzögert.

## Ursachen

- `setCameraOrbit` im `flutter_3d_controller` erwartet den Radius als **Prozentwert** (Standard: `105%`). Es wurde fälschlich `2.35` übergeben → effektiv `2.35%` Zoom.
- `noteLetter` enthielt bereits `♯` aus dem Notennamen, zusätzlich wurde bei Abweichung ein zweites `tuningSymbol` angehängt.
- Die Tap-Animation wurde **vor** der Tonwiedergabe abgewartet (~400 ms Verzögerung).

## Änderungen

- Kamera auf Modellmitte und `115%` Radius gesetzt; Rotation beim Resonieren dezenter (14°/s).
- Notenanzeige: natürlicher Buchstabe + separates Vorzeichen; bei gerundeter Frequenz keine zusätzlichen Abweichungs-Symbole.
- Referenzton startet sofort; Stabilizer wird beim Tippen zurückgesetzt.
- Pitch-Detector verarbeitet Samples seriell, um Sprünge durch parallele Verarbeitung zu vermeiden.

## Tests

- `flutter test test/features/settings/tuning_pitch_label_test.dart` ✅
- `flutter analyze lib/features/settings/` ✅ (nur vorbestehende Info in anderer Datei)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b74cd39f-b95b-4747-9974-a2bb85fdd286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b74cd39f-b95b-4747-9974-a2bb85fdd286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

