### PR TITLE
Live Activities: Glass-Lockscreen, Sekunden-Countdown und Push-Fixes

### DIFF
--- a/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
+++ b/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
@@ -58,17 +58,14 @@ private func formatTime(_ date: Date) -> String {
   return formatter.string(from: date)
 }
 
-private func nextMinuteBoundary(from now: Date = Date()) -> Date {
-  let calendar = Calendar.current
-  let floored = calendar.date(bySetting: .second, value: 0, of: now) ?? now
-  return calendar.date(byAdding: .minute, value: 1, to: floored) ?? floored
+private func remainingSeconds(until end: Date, now: Date) -> Int {
+  max(0, Int(end.timeIntervalSince(now)))
 }
 
-private func remainingMinutes(until end: Date, now: Date) -> Int {
-  let calendar = Calendar.current
-  let flooredNow = calendar.date(bySetting: .second, value: 0, of: now) ?? now
-  let seconds = max(0, Int(end.timeIntervalSince(flooredNow)))
-  return (seconds + 59) / 60
+private func formatCountdown(seconds: Int) -> String {
+  let minutes = seconds / 60
+  let secs = seconds % 60
+  return String(format: "%d:%02d", minutes, secs)
 }
 
 private func compactTitle(_ title: String) -> String {
@@ -191,9 +188,9 @@ private struct ScheduleProgressSection: View {
           .font(.system(size: timeFontSize, weight: .regular))
           .foregroundColor(.white)
         Spacer()
-        TimelineView(.periodic(from: nextMinuteBoundary(), by: 60)) { timeline in
-          Text("Noch \(remainingMinutes(until: data.segmentEnd, now: timeline.date)) Min.")
-            .font(.system(size: timeFontSize, weight: .regular))
+        TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
+          Text("Noch \(formatCountdown(remainingSeconds(until: data.segmentEnd, now: timeline.date)))")
+            .font(.system(size: timeFontSize, weight: .regular).monospacedDigit())
             .foregroundColor(.white)
         }
         Spacer()
@@ -233,7 +230,7 @@ private struct ScheduleLiveActivityLayout {
     barOuterHeight: 15,
     horizontalPadding: 30,
     verticalPadding: 32,
-    showsBackground: true
+    showsBackground: false
   )
 
   // Die DynamicIslandExpandedRegion bringt bereits eigene System-Insets und
@@ -296,11 +293,32 @@ private struct ScheduleLiveActivityView: View {
 }
 
 @available(iOSApplicationExtension 16.1, *)
+private struct ScheduleLiveActivityLockScreenGlassBackground: View {
+  var body: some View {
+    if #available(iOSApplicationExtension 26.0, *) {
+      Rectangle()
+        .fill(.clear)
+        .glassEffect(.regular, in: .rect(cornerRadius: 22))
+    } else {
+      Rectangle()
+        .fill(.ultraThinMaterial)
+    }
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
 private struct ScheduleLiveActivityLockScreenView: View {
   let data: ScheduleLiveData
+  @Environment(\.showsWidgetContainerBackground) private var showsWidgetContainerBackground
 
   var body: some View {
     ScheduleLiveActivityView(data: data, layout: .lockScreen)
+      .background {
+        if showsWidgetContainerBackground {
+          ScheduleLiveActivityLockScreenGlassBackground()
+            .ignoresSafeArea()
+        }
+      }
   }
 }
 
@@ -320,7 +338,7 @@ struct ChronoScheduleLiveActivity: Widget {
       let data = ScheduleLiveData(context: context)
       ScheduleLiveActivityLockScreenView(data: data)
         .widgetURL(scheduleDeepLink(for: data.eventId))
-        .activityBackgroundTint(.black)
+        .activityBackgroundTint(.clear)
         .activitySystemActionForegroundColor(.white)
     } dynamicIsland: { context in
       let data = ScheduleLiveData(context: context)
@@ -343,8 +361,8 @@ struct ChronoScheduleLiveActivity: Widget {
             .minimumScaleFactor(0.75)
         }
       } compactTrailing: {
-        TimelineView(.periodic(from: nextMinuteBoundary(), by: 60)) { timeline in
-          Text("\(remainingMinutes(until: data.segmentEnd, now: timeline.date))m")
+        TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
+          Text(formatCountdown(remainingSeconds(until: data.segmentEnd, now: timeline.date)))
             .font(.footnote.monospacedDigit().weight(.semibold))
             .foregroundColor(.white)
         }

--- a/lib/features/calendar/live_activity/domain/schedule_live_activity_snapshot.dart
+++ b/lib/features/calendar/live_activity/domain/schedule_live_activity_snapshot.dart
@@ -34,17 +34,18 @@ class ScheduleLiveActivitySnapshot {
     return (nowMs - start) / (end - start);
   }
 
-  /// Verbleibende Minuten, synchron an Minutengrenzen (wie iOS-Widget).
+  /// Verbleibende Sekunden bis Segmentende (Countdown läuft nativ im Widget).
+  int remainingSecondsAt(DateTime now) {
+    final endMs = segmentEndMs;
+    final nowMs = now.millisecondsSinceEpoch;
+    final seconds = ((endMs - nowMs) / 1000).ceil();
+    if (seconds <= 0) return 0;
+    return seconds;
+  }
+
+  /// Verbleibende Minuten (abgerundet aus Sekunden).
   int remainingMinutesAt(DateTime now) {
-    final end = DateTime.fromMillisecondsSinceEpoch(segmentEndMs);
-    final flooredNow = DateTime(
-      now.year,
-      now.month,
-      now.day,
-      now.hour,
-      now.minute,
-    );
-    final seconds = end.difference(flooredNow).inSeconds;
+    final seconds = remainingSecondsAt(now);
     if (seconds <= 0) return 0;
     return (seconds + 59) ~/ 60;
   }

--- a/supabase/functions/_shared/fcm_v1.ts
+++ b/supabase/functions/_shared/fcm_v1.ts
@@ -128,7 +128,7 @@ export type LiveActivityFcmPayload = {
   event: LiveActivityFcmEvent;
   activityId: string;
   contentState: Record<string, string | number>;
-  liveActivityToken?: string | null;
+  liveActivityPushToken?: string | null;
   pushToStartToken?: string | null;
   eventId: string;
 };

--- a/supabase/functions/schedule-live-activity/index.ts
+++ b/supabase/functions/schedule-live-activity/index.ts
@@ -1,6 +1,9 @@
 /**
  * pg_cron → FCM Live Activities (start/end an Segmentgrenzen).
  * DB-Trigger (calendar_events, event_schedules) → FCM update/end bei Inhaltsänderungen.
+ *
+ * Countdown läuft nativ auf dem Gerät (iOS TimelineView / Android Chronometer).
+ * Server sendet nur: start (Push-to-Start), update (Inhaltsänderung), end.
  */
 
 import { createClient } from "npm:@supabase/supabase-js@2.49.1";
@@ -78,7 +81,14 @@ type ChangeRequest = {
 
 type SendOptions = {
   skipDedup?: boolean;
+  dedupAction?: LiveActivityFcmEvent;
 };
+
+function resolveSegmentStartEvent(device: DeviceRow): LiveActivityFcmEvent {
+  const liveToken = device.live_activity_push_token?.trim();
+  // Bereits laufende Activity → nur Inhalt aktualisieren, kein erneutes Push-to-Start.
+  return liveToken && liveToken.length > 0 ? "update" : "start";
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -169,10 +179,19 @@ function effectiveEnd(schedule: ScheduleRow): Date {
   return new Date(endRaw);
 }
 
+const SCHEDULE_TIMEZONE = "Europe/Berlin";
+
+function localDateKey(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: SCHEDULE_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
 function isSameLocalDay(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
+  return localDateKey(a) === localDateKey(b);
 }
 
 function visibleSchedulesToday(
@@ -314,7 +333,7 @@ async function sendForDevice(
       scheduleId,
       device.user_id,
       device.device_id,
-      fcmEvent,
+      options?.dedupAction ?? fcmEvent,
     )
   ) {
     return "skipped";
@@ -342,7 +361,7 @@ async function sendForDevice(
         scheduleId,
         device.user_id,
         device.device_id,
-        fcmEvent,
+        options?.dedupAction ?? fcmEvent,
       );
     }
     return "sent";
@@ -542,7 +561,9 @@ async function handleContentChange(
       device.device_id,
       "start",
     );
-    const fcmEvent: LiveActivityFcmEvent = alreadyStarted ? "update" : "start";
+    const fcmEvent: LiveActivityFcmEvent = alreadyStarted
+      ? "update"
+      : resolveSegmentStartEvent(device);
     const contentState = snapshotToContentState(snapshot, eventId);
 
     const result = await sendForDevice(
@@ -674,14 +695,16 @@ async function handleCronTick(
       }
 
       const contentState = snapshotToContentState(snapshot, startRow.event_id);
+      const fcmEvent = resolveSegmentStartEvent(device);
       const result = await sendForDevice(
         supabase,
         serviceAccount,
         device,
         startRow.event_id,
         startRow.id,
-        "start",
+        fcmEvent,
         contentState,
+        { dedupAction: "start" },
       );
       if (result === "sent") sent++;
       else if (result === "failed") failed++;

--- a/supabase/migrations/20260701120000_schedule_live_activity_cron_fix.sql
+++ b/supabase/migrations/20260701120000_schedule_live_activity_cron_fix.sql
@@ -1,0 +1,33 @@
+-- Live Activity Cron: wieder jede Minute (±30s Fenster in Edge Function).
+-- Der 5-Minuten-Cron hat Segmentstarts zwischen den Ticks verpasst.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'schedule-live-activity') THEN
+    PERFORM cron.unschedule(jobid)
+    FROM cron.job
+    WHERE jobname = 'schedule-live-activity';
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'schedule-live-activity',
+  '* * * * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://chrbvfaknykaycwumuba.supabase.co/functions/v1/schedule-live-activity',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', coalesce(
+        (SELECT decrypted_secret FROM vault.decrypted_secrets
+         WHERE name = 'schedule_live_activity_cron_secret' LIMIT 1),
+        ''
+      )
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+COMMENT ON EXTENSION pg_cron IS
+  'schedule-live-activity: jede Minute für zuverlässige Segment-Starts (±30s).';

--- a/test/features/calendar/live_activity/schedule_live_activity_logic_test.dart
+++ b/test/features/calendar/live_activity/schedule_live_activity_logic_test.dart
@@ -27,14 +27,22 @@ void main() {
       );
     });
 
-    test('zeigt 30 Min bei Start in derselben Minute', () {
+    test('zeigt 30:13 bei 13 Sekunden nach Segmentstart', () {
+      expect(
+        snapshot.remainingSecondsAt(DateTime(2026, 6, 24, 10, 0, 47)),
+        30 * 60 - 47,
+      );
       expect(
         snapshot.remainingMinutesAt(DateTime(2026, 6, 24, 10, 0, 47)),
         30,
       );
     });
 
-    test('wechselt an Minutengrenze auf 29 Min', () {
+    test('wechselt sekundengenau auf 29:00 an der Minutengrenze', () {
+      expect(
+        snapshot.remainingSecondsAt(DateTime(2026, 6, 24, 10, 1, 0)),
+        29 * 60,
+      );
       expect(
         snapshot.remainingMinutesAt(DateTime(2026, 6, 24, 10, 1, 0)),
         29,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Verbessert Live Activities (Push, Countdown, Lockscreen-Sichtbarkeit).

## Änderungen

### iOS Lockscreen
- Schwarzer Banner-Hintergrund entfernt
- **Liquid Glass** auf iOS 26 (`glassEffect(.regular)`), sonst `ultraThinMaterial`
- `activityBackgroundTint(.clear)` — System-Glass an den Seiten bleibt sichtbar
- `showsWidgetContainerBackground` für randfüllenden Hintergrund

### iOS Countdown
- Anzeige `29:47` statt nur Minuten (sekündliches `TimelineView`)

### Backend (`schedule-live-activity`)
- Zeitzone `Europe/Berlin` für „heute“-Filter
- Push nur bei Segmentstart: erstes Segment `start` (Push-to-Start), Folgesegmente `update`
- Cron-Migration: wieder **jede Minute** (5-Min-Cron hat Starts verpasst)

### Dart
- `remainingSecondsAt()` für konsistente Countdown-Logik

## Supabase-Deploy

Migration und Edge Function müssen noch deployed werden (DB-Timeout in der Cloud-Umgebung):

```bash
supabase db push
supabase functions deploy schedule-live-activity
```

Oder Migration `20260701120000_schedule_live_activity_cron_fix.sql` im SQL Editor ausführen.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed762387-33a4-48ce-8e09-61a4972ff967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed762387-33a4-48ce-8e09-61a4972ff967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

