### PR TITLE
feat: Stundenplan-Live-Activity für Unterricht und Mittagessen

### DIFF
--- a/android/app/src/main/kotlin/com/domspatzen/chronoapp/ChronoLiveActivityManager.kt
+++ b/android/app/src/main/kotlin/com/domspatzen/chronoapp/ChronoLiveActivityManager.kt
@@ -4,12 +4,15 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.os.SystemClock
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
 import com.istornz.live_activities.LiveActivityManager
+import org.json.JSONArray
+import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -24,7 +27,31 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
         RemoteViews(appContext.packageName, R.layout.live_activity_expanded)
     private val timeFormat = SimpleDateFormat("HH:mm", Locale.GERMANY)
 
-    private fun pendingIntentFor(eventId: String): PendingIntent {
+    private data class TimetableSegment(
+        val id: String,
+        val type: String,
+        val title: String,
+        val subtitle: String,
+        val startMs: Long,
+        val endMs: Long,
+        val accentColor: String,
+        val imageUrl: String?,
+    )
+
+    private data class ResolvedSegment(
+        val title: String,
+        val subtitle: String,
+        val segmentStartMs: Long,
+        val segmentEndMs: Long,
+        val hasNext: Boolean,
+        val nextTitle: String,
+        val nextSubtitle: String,
+        val remainingLessons: Int,
+        val isMeal: Boolean,
+        val imageUrl: String?,
+    )
+
+    private fun pendingIntentForSchedule(eventId: String): PendingIntent {
         val intent = Intent(appContext, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP
             if (eventId.isNotEmpty()) {
@@ -36,6 +63,23 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
         return PendingIntent.getActivity(
             appContext,
             eventId.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun pendingIntentForTimetable(dayDate: String): PendingIntent {
+        val intent = Intent(appContext, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            if (dayDate.isNotEmpty()) {
+                data = Uri.parse(
+                    "chronoapp://timetable?date=${Uri.encode(dayDate)}",
+                )
+            }
+        }
+        return PendingIntent.getActivity(
+            appContext,
+            dayDate.hashCode(),
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
@@ -86,15 +130,180 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
         views.setViewVisibility(R.id.remaining_chronometer, View.VISIBLE)
     }
 
+    private fun parseSegments(rawJson: String?): List<TimetableSegment> {
+        if (rawJson.isNullOrBlank()) return emptyList()
+        return try {
+            val array = JSONArray(rawJson)
+            buildList {
+                for (i in 0 until array.length()) {
+                    val obj = array.optJSONObject(i) ?: continue
+                    add(
+                        TimetableSegment(
+                            id = obj.optString("id"),
+                            type = obj.optString("type"),
+                            title = obj.optString("title"),
+                            subtitle = obj.optString("subtitle"),
+                            startMs = obj.optLong("startMs"),
+                            endMs = obj.optLong("endMs"),
+                            accentColor = obj.optString("accentColor", "#124E30"),
+                            imageUrl = obj.optString("imageUrl").ifBlank { null },
+                        ),
+                    )
+                }
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun resolveTimetable(
+        segments: List<TimetableSegment>,
+        activityStartMs: Long,
+        nowMs: Long,
+    ): ResolvedSegment? {
+        if (segments.isEmpty()) return null
+        val first = segments.first()
+        if (nowMs < first.startMs) {
+            val next = segments.getOrNull(1)
+            return ResolvedSegment(
+                title = first.title,
+                subtitle = first.subtitle,
+                segmentStartMs = activityStartMs,
+                segmentEndMs = first.startMs,
+                hasNext = next != null,
+                nextTitle = next?.title ?: "",
+                nextSubtitle = next?.subtitle ?: "",
+                remainingLessons = remainingLessonCount(segments, 0, nowMs),
+                isMeal = first.type == "meal",
+                imageUrl = first.imageUrl,
+            )
+        }
+
+        segments.forEachIndexed { index, segment ->
+            if (nowMs < segment.endMs) {
+                val next = segments.getOrNull(index + 1)
+                return ResolvedSegment(
+                    title = segment.title,
+                    subtitle = segment.subtitle,
+                    segmentStartMs = segment.startMs,
+                    segmentEndMs = segment.endMs,
+                    hasNext = next != null,
+                    nextTitle = next?.title ?: "",
+                    nextSubtitle = next?.subtitle ?: "",
+                    remainingLessons = remainingLessonCount(segments, index, nowMs),
+                    isMeal = segment.type == "meal",
+                    imageUrl = segment.imageUrl,
+                )
+            }
+        }
+        return null
+    }
+
+    private fun remainingLessonCount(
+        segments: List<TimetableSegment>,
+        fromIndex: Int,
+        nowMs: Long,
+    ): Int {
+        var count = 0
+        for (i in fromIndex until segments.size) {
+            val segment = segments[i]
+            if (segment.type != "lesson") continue
+            if (i == fromIndex && nowMs >= segment.endMs) continue
+            count++
+        }
+        return count
+    }
+
+    private fun remainingLessonsLabel(count: Int): String {
+        return if (count == 1) "Noch 1 Stunde" else "Noch $count Stunden"
+    }
+
     private fun updateRemoteViews(views: RemoteViews, data: Map<String, Any>, expanded: Boolean) {
         applyThemeColors(views, expanded)
+        val kind = data["kind"] as? String ?: "schedule"
+        val now = System.currentTimeMillis()
+
+        if (kind == "timetable") {
+            val segments = parseSegments(data["segmentsJson"] as? String)
+            val activityStartMs = (data["activityStartMs"] as? Number)?.toLong()
+                ?: segments.firstOrNull()?.startMs
+                ?: now
+            val resolved = resolveTimetable(segments, activityStartMs, now) ?: return
+
+            val subtitle = buildString {
+                if (resolved.remainingLessons > 0) {
+                    append(remainingLessonsLabel(resolved.remainingLessons))
+                }
+                if (resolved.subtitle.isNotBlank()) {
+                    if (isNotEmpty()) append(" · ")
+                    append(resolved.subtitle)
+                }
+            }
+
+            views.setTextViewText(R.id.current_title, resolved.title)
+            applyCountdownChronometer(views, resolved.segmentEndMs)
+
+            if (resolved.isMeal && !resolved.imageUrl.isNullOrBlank() && expanded) {
+                views.setViewVisibility(R.id.arrow_icon, View.GONE)
+                views.setViewVisibility(R.id.next_column, View.VISIBLE)
+                views.setViewVisibility(R.id.next_title, View.VISIBLE)
+                views.setTextViewText(R.id.next_title, "")
+                try {
+                    views.setImageViewUri(
+                        R.id.next_title,
+                        Uri.parse(resolved.imageUrl),
+                    )
+                } catch (_: Exception) {
+                    views.setTextViewText(R.id.next_title, "Mittagessen")
+                }
+            } else if (resolved.hasNext) {
+                views.setViewVisibility(R.id.arrow_icon, View.VISIBLE)
+                views.setViewVisibility(R.id.next_title, View.VISIBLE)
+                views.setTextViewText(R.id.next_title, resolved.nextTitle)
+            } else {
+                views.setViewVisibility(R.id.arrow_icon, View.GONE)
+                views.setViewVisibility(R.id.next_title, View.GONE)
+            }
+
+            if (!expanded) return
+
+            setTextOrHide(views, R.id.current_subtitle, subtitle)
+            if (!resolved.isMeal) {
+                if (resolved.hasNext) {
+                    views.setViewVisibility(R.id.next_column, View.VISIBLE)
+                    setTextOrHide(views, R.id.next_subtitle, resolved.nextSubtitle)
+                } else {
+                    views.setViewVisibility(R.id.next_column, View.GONE)
+                }
+            }
+
+            views.setTextViewText(
+                R.id.segment_start,
+                timeFormat.format(Date(resolved.segmentStartMs)),
+            )
+            views.setTextViewText(
+                R.id.segment_end,
+                timeFormat.format(Date(resolved.segmentEndMs)),
+            )
+
+            val startMs = resolved.segmentStartMs
+            val endMs = resolved.segmentEndMs
+            val progress = if (endMs <= startMs) {
+                1000
+            } else {
+                val ratio = (now - startMs).toDouble() / (endMs - startMs).toDouble()
+                (min(1.0, max(0.0, ratio)) * 1000).toInt()
+            }
+            views.setProgressBar(R.id.segment_progress, 1000, progress, false)
+            return
+        }
+
         val currentTitle = data["currentTitle"] as? String ?: ""
         val currentSubtitle = data["currentSubtitle"] as? String ?: ""
         val nextTitle = data["nextTitle"] as? String ?: ""
         val nextSubtitle = data["nextSubtitle"] as? String ?: ""
         val startMs = (data["segmentStartMs"] as? Number)?.toLong() ?: 0L
         val endMs = (data["segmentEndMs"] as? Number)?.toLong() ?: 0L
-        val now = System.currentTimeMillis()
         val hasNext = nextTitle.isNotBlank()
 
         views.setTextViewText(R.id.current_title, currentTitle)
@@ -140,12 +349,20 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
         updateRemoteViews(collapsedViews, data, expanded = false)
         updateRemoteViews(expandedViews, data, expanded = true)
 
-        val eventId = data["eventId"] as? String ?: ""
+        val kind = data["kind"] as? String ?: "schedule"
+        val contentIntent = if (kind == "timetable") {
+            val dayDate = data["dayDate"] as? String ?: ""
+            pendingIntentForTimetable(dayDate)
+        } else {
+            val eventId = data["eventId"] as? String ?: ""
+            pendingIntentForSchedule(eventId)
+        }
+
         return notification
             .setSmallIcon(R.mipmap.ic_launcher)
             .setOngoing(true)
             .setShowWhen(false)
-            .setContentIntent(pendingIntentFor(eventId))
+            .setContentIntent(contentIntent)
             .setCustomContentView(collapsedViews)
             .setCustomBigContentView(expandedViews)
             .setPriority(Notification.PRIORITY_LOW)

--- a/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
+++ b/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
@@ -83,6 +83,146 @@ private func scheduleDeepLink(for eventId: String) -> URL? {
   return components.url
 }
 
+private func timetableDeepLink(for dayDate: String) -> URL? {
+  guard !dayDate.isEmpty else { return nil }
+  var components = URLComponents()
+  components.scheme = "chronoapp"
+  components.host = "timetable"
+  components.queryItems = [URLQueryItem(name: "date", value: dayDate)]
+  return components.url
+}
+
+private func readKind(context: ActivityViewContext<LiveActivitiesAppAttributes>) -> String {
+  let key = context.attributes.prefixedKey("kind")
+  return sharedDefault.string(forKey: key) ?? "schedule"
+}
+
+private struct TimetableSegment: Codable {
+  let id: String
+  let type: String
+  let title: String
+  let subtitle: String
+  let startMs: Double
+  let endMs: Double
+  let accentColor: String
+  let imageUrl: String?
+}
+
+private struct TimetableResolvedSegment {
+  let index: Int
+  let title: String
+  let subtitle: String
+  let segmentStart: Date
+  let segmentEnd: Date
+  let accentColor: Color
+  let isMeal: Bool
+  let imageUrl: String?
+  let hasNext: Bool
+  let nextTitle: String
+  let nextSubtitle: String
+  let remainingLessons: Int
+  let isPreStart: Bool
+}
+
+private struct TimetableLiveData {
+  let dayDate: String
+  let segments: [TimetableSegment]
+  let activityStartMs: Double
+
+  init(context: ActivityViewContext<LiveActivitiesAppAttributes>) {
+    func key(_ name: String) -> String {
+      context.attributes.prefixedKey(name)
+    }
+    dayDate = sharedDefault.string(forKey: key("dayDate")) ?? ""
+    activityStartMs = sharedDefault.double(forKey: key("activityStartMs"))
+    let rawJson = sharedDefault.string(forKey: key("segmentsJson")) ?? "[]"
+    if let data = rawJson.data(using: .utf8),
+       let decoded = try? JSONDecoder().decode([TimetableSegment].self, from: data) {
+      segments = decoded
+    } else {
+      segments = []
+    }
+  }
+
+  func resolve(at now: Date) -> TimetableResolvedSegment? {
+    guard !segments.isEmpty else { return nil }
+    let nowMs = now.timeIntervalSince1970 * 1000
+    let activityStart = Date(timeIntervalSince1970: activityStartMs / 1000)
+    let first = segments[0]
+
+    if nowMs < first.startMs {
+      let next = segments.count > 1 ? segments[1] : nil
+      return TimetableResolvedSegment(
+        index: 0,
+        title: first.title,
+        subtitle: first.subtitle,
+        segmentStart: activityStart,
+        segmentEnd: Date(timeIntervalSince1970: first.startMs / 1000),
+        accentColor: parseHexColor(first.accentColor),
+        isMeal: first.type == "meal",
+        imageUrl: first.imageUrl,
+        hasNext: next != nil,
+        nextTitle: next?.title ?? "",
+        nextSubtitle: next?.subtitle ?? "",
+        remainingLessons: remainingLessonCount(fromIndex: 0, nowMs: nowMs),
+        isPreStart: true
+      )
+    }
+
+    for (index, segment) in segments.enumerated() {
+      if nowMs < segment.endMs {
+        let next = index + 1 < segments.count ? segments[index + 1] : nil
+        return TimetableResolvedSegment(
+          index: index,
+          title: segment.title,
+          subtitle: segment.subtitle,
+          segmentStart: Date(timeIntervalSince1970: segment.startMs / 1000),
+          segmentEnd: Date(timeIntervalSince1970: segment.endMs / 1000),
+          accentColor: parseHexColor(segment.accentColor),
+          isMeal: segment.type == "meal",
+          imageUrl: segment.imageUrl,
+          hasNext: next != nil,
+          nextTitle: next?.title ?? "",
+          nextSubtitle: next?.subtitle ?? "",
+          remainingLessons: remainingLessonCount(fromIndex: index, nowMs: nowMs),
+          isPreStart: false
+        )
+      }
+    }
+    return nil
+  }
+
+  private func remainingLessonCount(fromIndex: Int, nowMs: Double) -> Int {
+    var count = 0
+    for i in fromIndex..<segments.count {
+      let segment = segments[i]
+      if segment.type != "lesson" { continue }
+      if i == fromIndex && nowMs >= segment.endMs { continue }
+      count += 1
+    }
+    return count
+  }
+}
+
+private func parseHexColor(_ hex: String) -> Color {
+  var cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+  if cleaned.hasPrefix("#") {
+    cleaned.removeFirst()
+  }
+  guard cleaned.count == 6, let value = Int(cleaned, radix: 16) else {
+    return Color(red: 0.07, green: 0.31, blue: 0.19)
+  }
+  let r = Double((value >> 16) & 0xFF) / 255.0
+  let g = Double((value >> 8) & 0xFF) / 255.0
+  let b = Double(value & 0xFF) / 255.0
+  return Color(red: r, green: g, blue: b)
+}
+
+private func remainingLessonsLabel(_ count: Int) -> String {
+  if count == 1 { return "Noch 1 Stunde" }
+  return "Noch \(count) Stunden"
+}
+
 @available(iOSApplicationExtension 16.1, *)
 private struct ScheduleColumn: View {
   let title: String
@@ -171,6 +311,176 @@ private struct ScheduleProgressBar: View {
       }
     }
     .frame(height: outerHeight)
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+private struct TimetableAccentProgressBar: View {
+  let progress: Double
+  let accentColor: Color
+  var outerHeight: CGFloat = 15
+
+  private var metrics: PillProgressMetrics { PillProgressMetrics(outerHeight: outerHeight) }
+
+  private var trackColor: Color {
+    Color(red: 50 / 255, green: 50 / 255, blue: 50 / 255)
+  }
+
+  var body: some View {
+    let inset = metrics.contentInset
+    let innerHeight = metrics.innerHeight
+    let clampedProgress = min(max(progress, 0), 1)
+
+    GeometryReader { geo in
+      let innerWidth = max(0, geo.size.width - inset * 2)
+
+      ZStack(alignment: .leading) {
+        Capsule()
+          .fill(trackColor)
+        Capsule()
+          .fill(accentColor.opacity(0.92))
+          .frame(width: max(0, innerWidth * clampedProgress), height: innerHeight)
+          .padding(.leading, inset)
+      }
+    }
+    .frame(height: outerHeight)
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+private struct TimetableMealThumbnail: View {
+  let imageUrl: String?
+
+  var body: some View {
+    Group {
+      if let imageUrl, let url = URL(string: imageUrl), !imageUrl.isEmpty {
+        AsyncImage(url: url) { phase in
+          switch phase {
+          case .success(let image):
+            image
+              .resizable()
+              .scaledToFill()
+          default:
+            Rectangle()
+              .fill(Color(red: 0.20, green: 0.20, blue: 0.20))
+          }
+        }
+      }
+    }
+    .frame(width: 34, height: 34)
+    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+private struct TimetableProgressSection: View {
+  let segmentStart: Date
+  let segmentEnd: Date
+  let accentColor: Color
+  var timeFontSize: CGFloat = 13
+  var barOuterHeight: CGFloat = 15
+
+  var body: some View {
+    VStack(spacing: 8) {
+      HStack {
+        Text(formatTime(segmentStart))
+          .font(.system(size: timeFontSize, weight: .regular))
+          .foregroundColor(.white)
+        Spacer()
+        TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
+          Text("Noch \(formatCountdown(seconds: remainingSeconds(until: segmentEnd, now: timeline.date)))")
+            .font(.system(size: timeFontSize, weight: .regular).monospacedDigit())
+            .foregroundColor(.white)
+        }
+        Spacer()
+        Text(formatTime(segmentEnd))
+          .font(.system(size: timeFontSize, weight: .regular))
+          .foregroundColor(.white)
+      }
+      TimelineView(.periodic(from: segmentStart, by: 1.0)) { timeline in
+        let total = segmentEnd.timeIntervalSince(segmentStart)
+        let elapsed = timeline.date.timeIntervalSince(segmentStart)
+        let p = total > 0 ? min(max(elapsed / total, 0), 1) : 1
+        TimetableAccentProgressBar(
+          progress: p,
+          accentColor: accentColor,
+          outerHeight: barOuterHeight
+        )
+      }
+    }
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+private struct TimetableLiveActivityView: View {
+  let data: TimetableLiveData
+  let layout: ScheduleLiveActivityLayout
+
+  var body: some View {
+    TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
+      if let resolved = data.resolve(at: timeline.date) {
+        VStack(alignment: .leading, spacing: layout.sectionSpacing) {
+          HStack(alignment: .center, spacing: layout.columnSpacing) {
+            ScheduleColumn(
+              title: resolved.title,
+              subtitle: resolved.subtitle,
+              alignment: .leading,
+              titleSize: layout.titleSize,
+              subtitleSize: layout.subtitleSize
+            )
+            if resolved.isMeal, let imageUrl = resolved.imageUrl, !imageUrl.isEmpty {
+              TimetableMealThumbnail(imageUrl: imageUrl)
+                .frame(width: 34)
+            } else if resolved.hasNext {
+              Image(systemName: "arrow.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(Color(red: 0.54, green: 0.54, blue: 0.54))
+                .frame(width: 20)
+              ScheduleColumn(
+                title: resolved.nextTitle,
+                subtitle: resolved.nextSubtitle,
+                alignment: .trailing,
+                titleSize: layout.titleSize,
+                subtitleSize: layout.subtitleSize
+              )
+            }
+          }
+
+          if resolved.remainingLessons > 0 {
+            Text(remainingLessonsLabel(resolved.remainingLessons))
+              .font(.system(size: layout.timeFontSize, weight: .medium))
+              .foregroundColor(Color(red: 0.67, green: 0.67, blue: 0.67))
+          }
+
+          TimetableProgressSection(
+            segmentStart: resolved.segmentStart,
+            segmentEnd: resolved.segmentEnd,
+            accentColor: resolved.accentColor,
+            timeFontSize: layout.timeFontSize,
+            barOuterHeight: layout.barOuterHeight
+          )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, layout.horizontalPadding)
+        .padding(.vertical, layout.verticalPadding)
+      }
+    }
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+private struct TimetableLiveActivityLockScreenView: View {
+  let data: TimetableLiveData
+  @Environment(\.showsWidgetContainerBackground) private var showsWidgetContainerBackground
+
+  var body: some View {
+    TimetableLiveActivityView(data: data, layout: .lockScreen)
+      .background {
+        if showsWidgetContainerBackground {
+          ScheduleLiveActivityLockScreenGlassBackground()
+            .ignoresSafeArea()
+        }
+      }
   }
 }
 
@@ -335,12 +645,54 @@ private struct ScheduleLiveActivityDynamicIslandView: View {
 struct ChronoScheduleLiveActivity: Widget {
   var body: some WidgetConfiguration {
     ActivityConfiguration(for: LiveActivitiesAppAttributes.self) { context in
-      let data = ScheduleLiveData(context: context)
-      ScheduleLiveActivityLockScreenView(data: data)
-        .widgetURL(scheduleDeepLink(for: data.eventId))
-        .activityBackgroundTint(.clear)
-        .activitySystemActionForegroundColor(.white)
+      let kind = readKind(context: context)
+      if kind == "timetable" {
+        let data = TimetableLiveData(context: context)
+        TimetableLiveActivityLockScreenView(data: data)
+          .widgetURL(timetableDeepLink(for: data.dayDate))
+          .activityBackgroundTint(.clear)
+          .activitySystemActionForegroundColor(.white)
+      } else {
+        let data = ScheduleLiveData(context: context)
+        ScheduleLiveActivityLockScreenView(data: data)
+          .widgetURL(scheduleDeepLink(for: data.eventId))
+          .activityBackgroundTint(.clear)
+          .activitySystemActionForegroundColor(.white)
+      }
     } dynamicIsland: { context in
+      let kind = readKind(context: context)
+      if kind == "timetable" {
+        let data = TimetableLiveData(context: context)
+        return DynamicIsland {
+          DynamicIslandExpandedRegion(.bottom) {
+            TimetableLiveActivityView(data: data, layout: .dynamicIsland)
+          }
+        } compactLeading: {
+          TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
+            if let resolved = data.resolve(at: timeline.date) {
+              Text(formatTime(resolved.segmentEnd))
+                .font(.footnote.monospacedDigit().weight(.semibold))
+                .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            }
+          }
+        } compactTrailing: {
+          TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
+            if let resolved = data.resolve(at: timeline.date) {
+              Text(formatCountdown(seconds: remainingSeconds(until: resolved.segmentEnd, now: timeline.date)))
+                .font(.footnote.monospacedDigit().weight(.semibold))
+                .foregroundColor(.white)
+            }
+          }
+        } minimal: {
+          Image(systemName: "book")
+            .font(.body.weight(.semibold))
+            .foregroundColor(.white)
+        }
+        .widgetURL(timetableDeepLink(for: data.dayDate))
+      }
+
       let data = ScheduleLiveData(context: context)
       return DynamicIsland {
         DynamicIslandExpandedRegion(.bottom) {

--- a/lib/core/push/firebase_messaging_background.dart
+++ b/lib/core/push/firebase_messaging_background.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../firebase_options.dart';
 import '../../features/calendar/live_activity/presentation/schedule_live_activity_coordinator.dart';
+import '../../features/calendar/timetable_live_activity/presentation/timetable_live_activity_coordinator.dart';
 
 /// Muss Top-Level-Funktion sein (Firebase-Anforderung).
 @pragma('vm:entry-point')
@@ -17,6 +18,13 @@ Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   final data = message.data;
   if (data['type'] == 'schedule_live_activity') {
     await ScheduleLiveActivityCoordinator.instance?.handleFcmData(
+      data.map((k, v) => MapEntry(k, v.toString())),
+    );
+    return;
+  }
+
+  if (data['type'] == 'timetable_live_activity') {
+    await TimetableLiveActivityCoordinator.instance?.handleFcmData(
       data.map((k, v) => MapEntry(k, v.toString())),
     );
     return;

--- a/lib/core/push/push_notification_service.dart
+++ b/lib/core/push/push_notification_service.dart
@@ -5,6 +5,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../features/calendar/live_activity/presentation/schedule_live_activity_coordinator.dart';
+import '../../features/calendar/timetable_live_activity/presentation/timetable_live_activity_coordinator.dart';
 import '../../features/login/presentation/services/guardian_link_bootstrap.dart';
 import 'push_device_repository.dart';
 
@@ -53,6 +54,12 @@ class PushNotificationService {
       );
       return;
     }
+    if (data['type'] == 'timetable_live_activity') {
+      unawaited(
+        TimetableLiveActivityCoordinator.instance?.handleFcmData(data),
+      );
+      return;
+    }
     if (kDebugMode) {
       debugPrint('[FCM] foreground: ${message.notification?.title}');
     }
@@ -64,6 +71,12 @@ class PushNotificationService {
     if (data['type'] == 'schedule_live_activity') {
       unawaited(
         ScheduleLiveActivityCoordinator.instance?.handleFcmData(data),
+      );
+      return;
+    }
+    if (data['type'] == 'timetable_live_activity') {
+      unawaited(
+        TimetableLiveActivityCoordinator.instance?.handleFcmData(data),
       );
     }
   }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -8,6 +8,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../features/calendar/home_widget/domain/calendar_home_widget_constants.dart';
 import '../../features/calendar/live_activity/live_activity_constants.dart';
 import '../../features/calendar/live_activity/presentation/schedule_live_activity_deep_link_pending.dart';
+import '../../features/calendar/timetable_live_activity/timetable_live_activity_constants.dart';
 import '../../features/calendar/presentation/pages/calendar_page.dart';
 import '../../features/login/presentation/providers/profile_gate_notifier.dart';
 import '../../features/login/presentation/routes/login_flow_specs.dart';
@@ -73,6 +74,11 @@ class AppRouter {
       final eventId = parseScheduleLiveActivityEventId(state.uri);
       if (eventId != null) {
         ScheduleLiveActivityDeepLinkPending.set(eventId);
+        router.go('/calendar');
+        return;
+      }
+      final timetableDay = parseTimetableLiveActivityDayDateKey(state.uri);
+      if (timetableDay != null) {
         router.go('/calendar');
         return;
       }
@@ -206,6 +212,10 @@ class AppRouter {
           }
           return '/calendar';
         },
+      ),
+      GoRoute(
+        path: '/timetable',
+        redirect: (context, state) => '/calendar',
       ),
       StatefulShellRoute.indexedStack(
         pageBuilder: (context, state, navigationShell) => NoTransitionPage(

--- a/lib/features/calendar/live_activity/data/schedule_live_activity_service.dart
+++ b/lib/features/calendar/live_activity/data/schedule_live_activity_service.dart
@@ -76,12 +76,19 @@ class ScheduleLiveActivityService {
   }
 
   Future<String?> createOrUpdate(ScheduleLiveActivitySnapshot snapshot) async {
+    return createOrUpdatePayload(
+      snapshot.customId,
+      snapshot.toActivityPayload(),
+    );
+  }
+
+  Future<String?> createOrUpdatePayload(
+    String customId,
+    Map<String, dynamic> payload,
+  ) async {
     if (!supportsLiveActivities || !_initialized) return null;
     try {
-      return await _plugin.createOrUpdateActivity(
-        snapshot.customId,
-        snapshot.toActivityPayload(),
-      );
+      return await _plugin.createOrUpdateActivity(customId, payload);
     } catch (e, st) {
       if (kDebugMode) {
         debugPrint('[LiveActivity] createOrUpdate failed: $e\n$st');

--- a/lib/features/calendar/live_activity/presentation/schedule_live_activity_bootstrap.dart
+++ b/lib/features/calendar/live_activity/presentation/schedule_live_activity_bootstrap.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import '../../../login/presentation/providers/profile_gate_notifier.dart';
 import 'schedule_live_activity_coordinator.dart';
 import 'schedule_live_activity_deep_link_handler.dart';
+import '../../timetable_live_activity/presentation/timetable_live_activity_coordinator.dart';
 
 /// Startet Live-Activity-Coordinator nach Login/Profil-Gate.
 class ScheduleLiveActivityBootstrap with WidgetsBindingObserver {
@@ -28,6 +29,7 @@ class ScheduleLiveActivityBootstrap with WidgetsBindingObserver {
   final GoRouter _router;
   ScheduleLiveActivityDeepLinkHandler? _deepLinkHandler;
   ScheduleLiveActivityCoordinator? _coordinator;
+  TimetableLiveActivityCoordinator? _timetableCoordinator;
   static ScheduleLiveActivityBootstrap? _instance;
 
   static void start({
@@ -49,6 +51,7 @@ class ScheduleLiveActivityBootstrap with WidgetsBindingObserver {
     _instance = null;
     unawaited(instance?._deepLinkHandler?.dispose());
     unawaited(instance?._coordinator?.dispose());
+    unawaited(instance?._timetableCoordinator?.dispose());
     instance?.dispose();
   }
 
@@ -81,14 +84,25 @@ class ScheduleLiveActivityBootstrap with WidgetsBindingObserver {
       _coordinator = coordinator;
       ScheduleLiveActivityCoordinator.instance = coordinator;
 
+      final timetableCoordinator =
+          _ref.read(timetableLiveActivityCoordinatorProvider);
+      _timetableCoordinator = timetableCoordinator;
+      TimetableLiveActivityCoordinator.instance = timetableCoordinator;
+
       if (!coordinator.isRunning) {
         await coordinator.start(
           onUrlScheme: _deepLinkHandler?.handleUrlSchemeData,
         );
-        return;
+      } else {
+        await coordinator.refreshNow();
       }
 
-      await coordinator.refreshNow();
+      if (!timetableCoordinator.isRunning) {
+        await timetableCoordinator.start();
+      } else {
+        await timetableCoordinator.refreshNow();
+      }
+      return;
     } catch (e, st) {
       if (kDebugMode) {
         debugPrint('[LiveActivity] bootstrap failed: $e\n$st');

--- a/lib/features/calendar/live_activity/presentation/schedule_live_activity_deep_link_handler.dart
+++ b/lib/features/calendar/live_activity/presentation/schedule_live_activity_deep_link_handler.dart
@@ -6,7 +6,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:live_activities/models/url_scheme_data.dart';
 
+import '../../presentation/providers/calendar_providers.dart';
 import '../live_activity_constants.dart';
+import '../../timetable_live_activity/timetable_live_activity_constants.dart';
 import 'schedule_live_activity_deep_link_pending.dart';
 import 'schedule_live_activity_open_request_provider.dart';
 
@@ -38,8 +40,24 @@ class ScheduleLiveActivityDeepLinkHandler {
       return;
     }
 
-    if (data.scheme != kLiveActivityUrlScheme ||
-        data.host != kLiveActivityScheduleDeepLinkHost) {
+    if (data.scheme != kLiveActivityUrlScheme) {
+      return;
+    }
+
+    if (data.host == kTimetableLiveActivityDeepLinkHost) {
+      for (final item in data.queryParameters) {
+        if (item['name'] == 'date') {
+          final dayDateKey = item['value']?.trim();
+          if (dayDateKey != null && dayDateKey.isNotEmpty) {
+            _openTimetable(dayDateKey);
+          }
+          return;
+        }
+      }
+      return;
+    }
+
+    if (data.host != kLiveActivityScheduleDeepLinkHost) {
       return;
     }
 
@@ -56,9 +74,35 @@ class ScheduleLiveActivityDeepLinkHandler {
 
   Future<void> _handleUri(Uri? uri) async {
     if (uri == null) return;
+
+    final timetableDay = parseTimetableLiveActivityDayDateKey(uri);
+    if (timetableDay != null) {
+      _openTimetable(timetableDay);
+      return;
+    }
+
     final eventId = parseScheduleLiveActivityEventId(uri);
     if (eventId == null) return;
     _openSchedule(eventId);
+  }
+
+  void _openTimetable(String dayDateKey) {
+    final parts = dayDateKey.split('-');
+    if (parts.length == 3) {
+      final year = int.tryParse(parts[0]);
+      final month = int.tryParse(parts[1]);
+      final day = int.tryParse(parts[2]);
+      if (year != null && month != null && day != null) {
+        _ref.read(selectedDayProvider.notifier).update(
+              DateTime(year, month, day),
+            );
+        _ref.read(focusedDayProvider.notifier).update(DateTime(year, month, day));
+      }
+    }
+    _router.go('/calendar');
+    if (kDebugMode) {
+      debugPrint('[LiveActivity] open timetable deep link for $dayDateKey');
+    }
   }
 
   void _openSchedule(String eventId) {

--- a/lib/features/calendar/timetable_live_activity/data/timetable_live_activity_data_source.dart
+++ b/lib/features/calendar/timetable_live_activity/data/timetable_live_activity_data_source.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+
+import 'package:chronoapp/core/database/powersync_schema.dart';
+import 'package:chronoapp/core/time/app_date_time.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:chronoapp/features/calendar/domain/repositories/calendar_repository.dart';
+import 'package:powersync/powersync.dart';
+
+/// Lokale Abfragen für Stundenplan-Live-Activities.
+class TimetableLiveActivityDataSource {
+  TimetableLiveActivityDataSource(this._repository);
+
+  final CalendarRepository _repository;
+
+  Stream<List<CalendarEntry>> watchEntriesForDay(DateTime day) {
+    return _repository.watchEntriesForDay(day);
+  }
+
+  Future<List<CalendarEntry>> entriesForDay(DateTime day) async {
+    return watchEntriesForDay(day).first;
+  }
+
+  Stream<void> watchTimetableChanges() {
+    return _repository.watchEntriesForDay(AppDateTime.todayLocal()).map((_) {});
+  }
+
+  /// Für lokale Notification-Planung: Activity-Start (15 min vor erster Stunde).
+  Future<List<({String dayDateKey, DateTime at})>> upcomingActivityStarts({
+    required DateTime rangeStart,
+    required DateTime rangeEndExclusive,
+  }) async {
+    final out = <({String dayDateKey, DateTime at})>[];
+    var day = AppDateTime.localDay(rangeStart);
+    final endDay = AppDateTime.localDay(rangeEndExclusive);
+
+    while (!day.isAfter(endDay)) {
+      final entries = await entriesForDay(day);
+      final lessons = entries
+          .where((e) => e.type == CalendarEntryType.lesson)
+          .toList()
+        ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+      if (lessons.isNotEmpty) {
+        final firstStart = AppDateTime.toLocal(lessons.first.startTime);
+        final activityStart = firstStart.subtract(
+          const Duration(minutes: 15),
+        );
+        if (!activityStart.isBefore(rangeStart) &&
+            activityStart.isBefore(rangeEndExclusive)) {
+          out.add((
+            dayDateKey: _dayKey(day),
+            at: activityStart,
+          ));
+        }
+      }
+
+      day = AppDateTime.addLocalCalendarDays(day, 1);
+    }
+
+    return out;
+  }
+
+  Future<List<({String dayDateKey, DateTime end})>> upcomingDayEnds({
+    required DateTime rangeStart,
+    required DateTime rangeEndExclusive,
+  }) async {
+    final out = <({String dayDateKey, DateTime end})>[];
+    var day = AppDateTime.localDay(rangeStart);
+    final endDay = AppDateTime.localDay(rangeEndExclusive);
+
+    while (!day.isAfter(endDay)) {
+      final entries = await entriesForDay(day);
+      final relevant = entries
+          .where(
+            (e) =>
+                e.type == CalendarEntryType.lesson ||
+                e.type == CalendarEntryType.meal,
+          )
+          .toList();
+      if (relevant.isNotEmpty) {
+        final last = relevant.reduce(
+          (a, b) => a.endTime.isAfter(b.endTime) ? a : b,
+        );
+        final localEnd = AppDateTime.toLocal(last.endTime);
+        if (!localEnd.isBefore(rangeStart) &&
+            localEnd.isBefore(rangeEndExclusive)) {
+          out.add((dayDateKey: _dayKey(day), end: localEnd));
+        }
+      }
+      day = AppDateTime.addLocalCalendarDays(day, 1);
+    }
+
+    return out;
+  }
+
+  String _dayKey(DateTime day) {
+    final local = AppDateTime.localDay(day);
+    final y = local.year.toString().padLeft(4, '0');
+    final m = local.month.toString().padLeft(2, '0');
+    final d = local.day.toString().padLeft(2, '0');
+    return '$y-$m-$d';
+  }
+}
+
+/// Triggert auf Kalenderänderungen (Events + Serien).
+Stream<void> watchTimetableCalendarChanges(PowerSyncDatabase db) {
+  return db
+      .watch(
+        'SELECT COUNT(*) AS c FROM $kCalendarEventsTable',
+        triggerOnTables: const {
+          kCalendarEventsTable,
+          kCalendarSeriesTable,
+          kSubjectsTable,
+        },
+      )
+      .map((_) {});
+}

--- a/lib/features/calendar/timetable_live_activity/data/timetable_live_activity_local_scheduler.dart
+++ b/lib/features/calendar/timetable_live_activity/data/timetable_live_activity_local_scheduler.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+
+import '../../../../core/time/app_date_time.dart';
+
+typedef TimetableLiveActivityNotificationHandler = Future<void> Function(
+  String payload,
+);
+
+/// Plant lokale Notifications für Stundenplan-Start (15 min vor erster Stunde).
+class TimetableLiveActivityLocalScheduler {
+  TimetableLiveActivityLocalScheduler({
+    FlutterLocalNotificationsPlugin? plugin,
+  }) : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  static const String channelId = 'timetable_live_activity';
+  static const String channelName = 'Stundenplan';
+  static const String endPayloadMarker = 'end';
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  TimetableLiveActivityNotificationHandler? _onPayload;
+  bool _initialized = false;
+
+  static int notificationIdForStart(String dayDateKey) {
+    return Object.hash('timetable_start', dayDateKey) & 0x7fffffff;
+  }
+
+  static int notificationIdForDayEnd(String dayDateKey) {
+    return Object.hash('timetable_day_end', dayDateKey) & 0x7fffffff;
+  }
+
+  Future<void> init({
+    required TimetableLiveActivityNotificationHandler onPayload,
+  }) async {
+    _onPayload = onPayload;
+    if (_initialized) return;
+
+    tz_data.initializeTimeZones();
+    try {
+      tz.setLocalLocation(tz.getLocation('Europe/Berlin'));
+    } catch (_) {
+      tz.setLocalLocation(tz.local);
+    }
+
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosInit = DarwinInitializationSettings();
+    await _plugin.initialize(
+      const InitializationSettings(
+        android: androidInit,
+        iOS: iosInit,
+      ),
+      onDidReceiveNotificationResponse: _onNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse:
+          timetableLiveActivityNotificationTapBackground,
+    );
+
+    if (Platform.isAndroid) {
+      await _plugin
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.createNotificationChannel(
+            const AndroidNotificationChannel(
+              channelId,
+              channelName,
+              description:
+                  'Startet die Stundenplan-Live-Activity vor Unterrichtsbeginn',
+              importance: Importance.low,
+              playSound: false,
+            ),
+          );
+    }
+
+    _initialized = true;
+  }
+
+  void _onNotificationResponse(NotificationResponse response) {
+    final payload = response.payload;
+    if (payload == null || payload.isEmpty) return;
+    unawaited(_onPayload?.call(payload));
+  }
+
+  Future<void> reschedule({
+    required List<({String dayDateKey, DateTime start})> starts,
+    required List<({String dayDateKey, DateTime end})> ends,
+  }) async {
+    if (!_initialized) return;
+
+    await _plugin.cancelAll();
+
+    final now = DateTime.now();
+    final rangeEnd = AppDateTime.addLocalCalendarDays(
+      AppDateTime.localDay(now),
+      2,
+    );
+
+    for (final entry in starts) {
+      final localStart = AppDateTime.toLocal(entry.start);
+      if (!localStart.isAfter(now)) continue;
+      if (!localStart.isBefore(rangeEnd)) continue;
+
+      await _schedule(
+        id: notificationIdForStart(entry.dayDateKey),
+        at: localStart,
+        payload: '${entry.dayDateKey}|start',
+      );
+    }
+
+    for (final entry in ends) {
+      final localEnd = AppDateTime.toLocal(entry.end);
+      if (!localEnd.isAfter(now)) continue;
+      if (!localEnd.isBefore(rangeEnd)) continue;
+
+      await _schedule(
+        id: notificationIdForDayEnd(entry.dayDateKey),
+        at: localEnd,
+        payload: '${entry.dayDateKey}|$endPayloadMarker',
+      );
+    }
+  }
+
+  Future<void> _schedule({
+    required int id,
+    required DateTime at,
+    required String payload,
+  }) async {
+    final tzTime = tz.TZDateTime.from(at, tz.local);
+    try {
+      await _plugin.zonedSchedule(
+        id,
+        null,
+        null,
+        tzTime,
+        NotificationDetails(
+          android: AndroidNotificationDetails(
+            channelId,
+            channelName,
+            importance: Importance.low,
+            priority: Priority.low,
+            playSound: false,
+            silent: true,
+            channelShowBadge: false,
+          ),
+          iOS: const DarwinNotificationDetails(
+            presentAlert: false,
+            presentSound: false,
+            presentBadge: false,
+          ),
+        ),
+        androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+        payload: payload,
+      );
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('[TimetableLiveActivity] schedule failed: $e\n$st');
+      }
+    }
+  }
+}
+
+@pragma('vm:entry-point')
+void timetableLiveActivityNotificationTapBackground(
+  NotificationResponse response,
+) {
+  if (kDebugMode) {
+    debugPrint(
+      '[TimetableLiveActivity] background notification: ${response.payload}',
+    );
+  }
+}

--- a/lib/features/calendar/timetable_live_activity/data/timetable_live_activity_service.dart
+++ b/lib/features/calendar/timetable_live_activity/data/timetable_live_activity_service.dart
@@ -1,0 +1,35 @@
+import 'package:chronoapp/features/calendar/live_activity/data/schedule_live_activity_service.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_snapshot.dart';
+
+/// Wrapper für Stundenplan-Live-Activities (teilt Plugin-Init mit Ablaufplan).
+class TimetableLiveActivityService {
+  TimetableLiveActivityService({ScheduleLiveActivityService? sharedService})
+      : _sharedService = sharedService ?? ScheduleLiveActivityService();
+
+  final ScheduleLiveActivityService _sharedService;
+
+  Future<bool> init() => _sharedService.init();
+
+  Future<bool> areActivitiesEnabled() => _sharedService.areActivitiesEnabled();
+
+  Future<String?> createOrUpdate(TimetableLiveActivitySnapshot snapshot) {
+    return _sharedService.createOrUpdatePayload(
+      snapshot.customId,
+      snapshot.toActivityPayload(),
+    );
+  }
+
+  Future<void> end(String customId) => _sharedService.end(customId);
+
+  set onLiveActivityPushToken(void Function(String token)? handler) {
+    _sharedService.onLiveActivityPushToken = handler;
+  }
+
+  set onPushToStartToken(void Function(String token)? handler) {
+    _sharedService.onPushToStartToken = handler;
+  }
+
+  set onUrlScheme(void Function(dynamic data)? handler) {
+    _sharedService.onUrlScheme = handler;
+  }
+}

--- a/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart
+++ b/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart
@@ -1,0 +1,254 @@
+import 'package:chronoapp/core/time/app_date_time.dart';
+import 'package:chronoapp/features/calendar/domain/filter/calendar_display_filters.dart';
+import 'package:chronoapp/features/calendar/domain/filter/calendar_filters_state.dart';
+import 'package:chronoapp/features/calendar/domain/meal_period.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_segment.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_snapshot.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/timetable_live_activity_constants.dart';
+import 'package:flutter/material.dart';
+
+typedef TimetableAccentResolver = Color Function(CalendarEntry entry);
+
+/// Ermittelt den Tages-Stundenplan für die Live Activity.
+abstract final class TimetableLiveActivityResolver {
+  TimetableLiveActivityResolver._();
+
+  static TimetableLiveActivitySnapshot? resolve({
+    required DateTime day,
+    required List<CalendarEntry> entries,
+    required CalendarFiltersState filters,
+    required TimetableAccentResolver resolveAccent,
+    String? imageUrlForEntry(CalendarEntry entry)?,
+    DateTime? now,
+  }) {
+    final clock = now ?? DateTime.now();
+    final localDay = AppDateTime.localDay(day);
+    if (!AppDateTime.isTodayLocal(localDay, now: clock)) {
+      if (clock.isBefore(localDay)) return null;
+    }
+
+    final filtered = applyCalendarDisplayFilters(
+      entries: entries,
+      filters: filters,
+      hideUnknownWhenFilterActive: false,
+      forEventList: true,
+    ).where((entry) {
+      if (entry.type != CalendarEntryType.lesson &&
+          entry.type != CalendarEntryType.meal) {
+        return false;
+      }
+      if (entry.type == CalendarEntryType.meal &&
+          resolveMealPeriod(entry.startTime) != MealPeriod.lunch) {
+        return false;
+      }
+      return AppDateTime.isSameLocalDay(entry.startTime, localDay);
+    }).toList()
+      ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+    if (filtered.isEmpty) return null;
+
+    final lessons = filtered
+        .where((e) => e.type == CalendarEntryType.lesson)
+        .toList(growable: false);
+    if (lessons.isEmpty) return null;
+
+    final firstLesson = lessons.first;
+    final firstLessonStart = AppDateTime.toLocal(firstLesson.startTime);
+    final activityStart = firstLessonStart.subtract(
+      const Duration(minutes: kTimetableLiveActivityPreStartMinutes),
+    );
+    final activityStartMs = activityStart.millisecondsSinceEpoch;
+
+    final segments = filtered
+        .map((entry) => _segmentFromEntry(
+              entry: entry,
+              resolveAccent: resolveAccent,
+              imageUrlForEntry: imageUrlForEntry,
+            ))
+        .toList(growable: false);
+
+    final lastEnd = segments
+        .map((s) => s.endMs)
+        .reduce((a, b) => a > b ? a : b);
+
+    if (clock.millisecondsSinceEpoch >= lastEnd) return null;
+    if (clock.isBefore(activityStart)) return null;
+
+    final dayDateKey = timetableDayDateKey(localDay);
+    final resolved = _resolveCurrent(
+      segments: segments,
+      activityStartMs: activityStartMs,
+      nowMs: clock.millisecondsSinceEpoch,
+    );
+    if (resolved == null) return null;
+
+    final remainingLessons = _remainingLessonCount(
+      segments: segments,
+      fromIndex: resolved.index,
+      nowMs: clock.millisecondsSinceEpoch,
+    );
+
+    final current = segments[resolved.index];
+    final next = resolved.index + 1 < segments.length
+        ? segments[resolved.index + 1]
+        : null;
+
+    return TimetableLiveActivitySnapshot(
+      dayDateKey: dayDateKey,
+      customId: liveActivityCustomIdForTimetableDay(dayDateKey),
+      segments: segments,
+      activityStartMs: activityStartMs,
+      dayEndMs: lastEnd,
+      currentIndex: resolved.index,
+      currentTitle: current.title,
+      currentSubtitle: current.subtitle,
+      hasNext: next != null,
+      nextTitle: next?.title ?? '',
+      nextSubtitle: next?.subtitle ?? '',
+      segmentStartMs: resolved.segmentStartMs,
+      segmentEndMs: resolved.segmentEndMs,
+      accentColorHex: current.accentColorHex,
+      isMeal: current.isMeal,
+      imageUrl: current.imageUrl ?? '',
+      remainingLessons: remainingLessons,
+      isPreStart: resolved.isPreStart,
+    );
+  }
+
+  static bool isDayFinished({
+    required DateTime day,
+    required List<CalendarEntry> entries,
+    required CalendarFiltersState filters,
+    DateTime? now,
+  }) {
+    final snapshot = resolve(
+      day: day,
+      entries: entries,
+      filters: filters,
+      resolveAccent: (_) => const Color(0xFF124E30),
+      now: now,
+    );
+    return snapshot == null;
+  }
+
+  static DateTime? activityStartForDay({
+    required DateTime day,
+    required List<CalendarEntry> entries,
+    required CalendarFiltersState filters,
+  }) {
+    final filtered = applyCalendarDisplayFilters(
+      entries: entries,
+      filters: filters,
+      hideUnknownWhenFilterActive: false,
+      forEventList: true,
+    ).where((e) => e.type == CalendarEntryType.lesson).toList()
+      ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+    if (filtered.isEmpty) return null;
+    final firstLessonStart = AppDateTime.toLocal(filtered.first.startTime);
+    return firstLessonStart.subtract(
+      const Duration(minutes: kTimetableLiveActivityPreStartMinutes),
+    );
+  }
+
+  static DateTime? dayEndForDay({
+    required DateTime day,
+    required List<CalendarEntry> entries,
+    required CalendarFiltersState filters,
+  }) {
+    final filtered = applyCalendarDisplayFilters(
+      entries: entries,
+      filters: filters,
+      hideUnknownWhenFilterActive: false,
+      forEventList: true,
+    ).where((entry) {
+      return entry.type == CalendarEntryType.lesson ||
+          (entry.type == CalendarEntryType.meal &&
+              resolveMealPeriod(entry.startTime) == MealPeriod.lunch);
+    }).toList();
+
+    if (filtered.isEmpty) return null;
+    final last = filtered.reduce(
+      (a, b) => a.endTime.isAfter(b.endTime) ? a : b,
+    );
+    return AppDateTime.toLocal(last.endTime);
+  }
+
+  static TimetableLiveActivitySegment _segmentFromEntry({
+    required CalendarEntry entry,
+    required TimetableAccentResolver resolveAccent,
+    String? Function(CalendarEntry entry)? imageUrlForEntry,
+  }) {
+    final start = AppDateTime.toLocal(entry.startTime);
+    final end = AppDateTime.toLocal(entry.endTime);
+    final subtitle = entry.type == CalendarEntryType.lesson
+        ? (entry.className?.trim().isNotEmpty == true
+            ? entry.className!.trim()
+            : entry.location?.trim() ?? '')
+        : '';
+
+    return TimetableLiveActivitySegment(
+      id: entry.id,
+      type: entry.type,
+      title: entry.eventName,
+      subtitle: subtitle,
+      startMs: start.millisecondsSinceEpoch,
+      endMs: end.millisecondsSinceEpoch,
+      accentColorHex: TimetableLiveActivitySegment.accentHexFor(
+        resolveAccent(entry),
+      ),
+      imageUrl: entry.type == CalendarEntryType.meal
+          ? imageUrlForEntry?.call(entry)
+          : null,
+    );
+  }
+
+  static ({int index, int segmentStartMs, int segmentEndMs, bool isPreStart})?
+      _resolveCurrent({
+    required List<TimetableLiveActivitySegment> segments,
+    required int activityStartMs,
+    required int nowMs,
+  }) {
+    if (segments.isEmpty) return null;
+
+    final first = segments.first;
+    if (nowMs < first.startMs) {
+      return (
+        index: 0,
+        segmentStartMs: activityStartMs,
+        segmentEndMs: first.startMs,
+        isPreStart: true,
+      );
+    }
+
+    for (var i = 0; i < segments.length; i++) {
+      final segment = segments[i];
+      if (nowMs < segment.endMs) {
+        return (
+          index: i,
+          segmentStartMs: segment.startMs,
+          segmentEndMs: segment.endMs,
+          isPreStart: false,
+        );
+      }
+    }
+
+    return null;
+  }
+
+  static int _remainingLessonCount({
+    required List<TimetableLiveActivitySegment> segments,
+    required int fromIndex,
+    required int nowMs,
+  }) {
+    var count = 0;
+    for (var i = fromIndex; i < segments.length; i++) {
+      final segment = segments[i];
+      if (!segment.isLesson) continue;
+      if (i == fromIndex && nowMs >= segment.endMs) continue;
+      count++;
+    }
+    return count;
+  }
+}

--- a/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_segment.dart
+++ b/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_segment.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+
+import 'package:chronoapp/features/calendar/data/subject_color_codec.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:flutter/material.dart';
+
+/// Ein Segment im Tages-Stundenplan (Unterricht oder Mittagessen).
+class TimetableLiveActivitySegment {
+  const TimetableLiveActivitySegment({
+    required this.id,
+    required this.type,
+    required this.title,
+    required this.subtitle,
+    required this.startMs,
+    required this.endMs,
+    required this.accentColorHex,
+    this.imageUrl,
+  });
+
+  final String id;
+  final CalendarEntryType type;
+  final String title;
+  final String subtitle;
+  final int startMs;
+  final int endMs;
+  final String accentColorHex;
+  final String? imageUrl;
+
+  bool get isMeal => type == CalendarEntryType.meal;
+  bool get isLesson => type == CalendarEntryType.lesson;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type.name,
+      'title': title,
+      'subtitle': subtitle,
+      'startMs': startMs,
+      'endMs': endMs,
+      'accentColor': accentColorHex,
+      if (imageUrl != null && imageUrl!.isNotEmpty) 'imageUrl': imageUrl,
+    };
+  }
+
+  static TimetableLiveActivitySegment? fromJson(Map<String, dynamic> json) {
+    final id = json['id']?.toString();
+    final typeRaw = json['type']?.toString();
+    final title = json['title']?.toString() ?? '';
+    final startMs = (json['startMs'] as num?)?.toInt();
+    final endMs = (json['endMs'] as num?)?.toInt();
+    if (id == null || typeRaw == null || startMs == null || endMs == null) {
+      return null;
+    }
+
+    CalendarEntryType? type;
+    for (final candidate in CalendarEntryType.values) {
+      if (candidate.name == typeRaw) {
+        type = candidate;
+        break;
+      }
+    }
+    if (type == null) return null;
+
+    final accent = json['accentColor']?.toString() ?? '#124E30';
+    return TimetableLiveActivitySegment(
+      id: id,
+      type: type,
+      title: title,
+      subtitle: json['subtitle']?.toString() ?? '',
+      startMs: startMs,
+      endMs: endMs,
+      accentColorHex: accent,
+      imageUrl: json['imageUrl']?.toString(),
+    );
+  }
+
+  static List<TimetableLiveActivitySegment> decodeList(String rawJson) {
+    if (rawJson.trim().isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(rawJson);
+      if (decoded is! List) return const [];
+      return decoded
+          .whereType<Map>()
+          .map((e) => TimetableLiveActivitySegment.fromJson(
+                Map<String, dynamic>.from(e),
+              ))
+          .whereType<TimetableLiveActivitySegment>()
+          .toList();
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  static String encodeList(List<TimetableLiveActivitySegment> segments) {
+    return jsonEncode(segments.map((s) => s.toJson()).toList());
+  }
+
+  static String accentHexFor(Color color) => SubjectColorCodec.toHex(color);
+}

--- a/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_snapshot.dart
+++ b/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_snapshot.dart
@@ -1,0 +1,78 @@
+import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_segment.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/timetable_live_activity_constants.dart';
+
+/// Anzeige-Daten für die Stundenplan-Live-Activity (voller Tagesplan im Payload).
+class TimetableLiveActivitySnapshot {
+  const TimetableLiveActivitySnapshot({
+    required this.dayDateKey,
+    required this.customId,
+    required this.segments,
+    required this.activityStartMs,
+    required this.dayEndMs,
+    required this.currentIndex,
+    required this.currentTitle,
+    required this.currentSubtitle,
+    required this.hasNext,
+    required this.nextTitle,
+    required this.nextSubtitle,
+    required this.segmentStartMs,
+    required this.segmentEndMs,
+    required this.accentColorHex,
+    required this.isMeal,
+    required this.imageUrl,
+    required this.remainingLessons,
+    required this.isPreStart,
+  });
+
+  final String dayDateKey;
+  final String customId;
+  final List<TimetableLiveActivitySegment> segments;
+  final int activityStartMs;
+  final int dayEndMs;
+  final int currentIndex;
+  final String currentTitle;
+  final String currentSubtitle;
+  final bool hasNext;
+  final String nextTitle;
+  final String nextSubtitle;
+  final int segmentStartMs;
+  final int segmentEndMs;
+  final String accentColorHex;
+  final bool isMeal;
+  final String imageUrl;
+  final int remainingLessons;
+  final bool isPreStart;
+
+  TimetableLiveActivitySegment? get currentSegment {
+    if (currentIndex < 0 || currentIndex >= segments.length) return null;
+    return segments[currentIndex];
+  }
+
+  String get contentFingerprint =>
+      '$dayDateKey|${TimetableLiveActivitySegment.encodeList(segments)}|'
+      '$currentIndex|$segmentStartMs|$segmentEndMs|$remainingLessons';
+
+  Map<String, dynamic> toActivityPayload() {
+    return {
+      'kind': kTimetableLiveActivityKind,
+      'dayDate': dayDateKey,
+      'segmentsJson': TimetableLiveActivitySegment.encodeList(segments),
+      'activityStartMs': activityStartMs,
+      'dayEndMs': dayEndMs,
+      'remainingLessons': remainingLessons,
+      'currentIndex': currentIndex,
+      'currentTitle': currentTitle,
+      'currentSubtitle': currentSubtitle,
+      'hasNext': hasNext,
+      'nextTitle': nextTitle,
+      'nextSubtitle': nextSubtitle,
+      'segmentStartMs': segmentStartMs,
+      'segmentEndMs': segmentEndMs,
+      'accentColor': accentColorHex,
+      'isMeal': isMeal,
+      'imageUrl': imageUrl,
+      'eventId': dayDateKey,
+      'isPreStart': isPreStart,
+    };
+  }
+}

--- a/lib/features/calendar/timetable_live_activity/presentation/timetable_live_activity_coordinator.dart
+++ b/lib/features/calendar/timetable_live_activity/presentation/timetable_live_activity_coordinator.dart
@@ -1,0 +1,323 @@
+import 'dart:async';
+
+import 'package:chronoapp/core/database/database_provider.dart';
+import 'package:chronoapp/core/time/app_date_time.dart';
+import 'package:chronoapp/features/calendar/data/calendar_image_url_resolver.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:chronoapp/features/calendar/live_activity/data/schedule_segment_timer_scheduler.dart';
+import 'package:chronoapp/features/calendar/data/calendar_signed_url_cache.dart';
+import 'package:chronoapp/features/calendar/presentation/providers/calendar_accent_overrides_provider.dart';
+import 'package:chronoapp/features/calendar/presentation/providers/calendar_providers.dart';
+import 'package:chronoapp/features/calendar/presentation/providers/subjects_providers.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/data/timetable_live_activity_data_source.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/data/timetable_live_activity_local_scheduler.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/data/timetable_live_activity_service.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_snapshot.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/timetable_live_activity_constants.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Steuert Start/Ende der Stundenplan-Live-Activity (voller Tagesplan im Payload).
+class TimetableLiveActivityCoordinator {
+  TimetableLiveActivityCoordinator({
+    required TimetableLiveActivityDataSource dataSource,
+    required TimetableLiveActivityService service,
+    required TimetableLiveActivityLocalScheduler localScheduler,
+    required ScheduleSegmentTimerScheduler segmentTimerScheduler,
+    required CalendarImageUrlResolver imageUrlResolver,
+    required Ref ref,
+  })  : _dataSource = dataSource,
+        _service = service,
+        _localScheduler = localScheduler,
+        _segmentTimerScheduler = segmentTimerScheduler,
+        _imageUrlResolver = imageUrlResolver,
+        _ref = ref;
+
+  final TimetableLiveActivityDataSource _dataSource;
+  final TimetableLiveActivityService _service;
+  final TimetableLiveActivityLocalScheduler _localScheduler;
+  final ScheduleSegmentTimerScheduler _segmentTimerScheduler;
+  final CalendarImageUrlResolver _imageUrlResolver;
+  final Ref _ref;
+
+  final Set<String> _activeCustomIds = {};
+  final Map<String, String> _lastContentFingerprint = {};
+  StreamSubscription<void>? _dbSub;
+  ProviderSubscription<CalendarFiltersState>? _filterSub;
+  bool _running = false;
+  bool _syncRunning = false;
+  bool _syncAgain = false;
+
+  bool get isRunning => _running;
+
+  static TimetableLiveActivityCoordinator? instance;
+
+  Future<void> start() async {
+    if (_running) return;
+    final enabled = await _service.init();
+    if (!enabled) return;
+
+    await _localScheduler.init(
+      onPayload: handleLocalNotificationPayload,
+    );
+    _running = true;
+
+    _dbSub = watchTimetableCalendarChanges(_ref.read(dbProvider)).listen((_) {
+      unawaited(_refresh());
+    });
+
+    _filterSub = _ref.listen(calendarFiltersProvider, (previous, next) {
+      if (previous != next) {
+        unawaited(_refresh());
+      }
+    });
+
+    unawaited(_refresh());
+  }
+
+  Future<void> refreshNow() async {
+    if (!_running) return;
+    await _refresh();
+    await _reconcileActiveState();
+  }
+
+  Future<void> dispose() async {
+    _running = false;
+    await _dbSub?.cancel();
+    _filterSub?.close();
+    _dbSub = null;
+    _filterSub = null;
+    _segmentTimerScheduler.dispose();
+  }
+
+  Future<void> handleLocalNotificationPayload(String payload) async {
+    final parts = payload.split('|');
+    if (parts.length != 2) return;
+    final dayDateKey = parts[0];
+    if (parts[1] == TimetableLiveActivityLocalScheduler.endPayloadMarker) {
+      await _endForDay(dayDateKey);
+      return;
+    }
+    await _activateForDay(dayDateKey);
+  }
+
+  Future<void> handleFcmData(Map<String, String> data) async {
+    final type = data['type'];
+    if (type != 'timetable_live_activity') return;
+
+    final event = data['event'] ?? 'update';
+    final dayDateKey = data['day_date'] ?? data['event_id'];
+    if (dayDateKey == null || dayDateKey.isEmpty) return;
+
+    if (event == 'end') {
+      await _endForDay(dayDateKey, customId: data['activity_id']);
+      return;
+    }
+
+    await _activateForDay(dayDateKey);
+  }
+
+  Future<void> _refresh() async {
+    if (!_running) return;
+
+    final now = DateTime.now();
+    final today = AppDateTime.localDay(now);
+    final dayAfterTomorrow = AppDateTime.addLocalCalendarDays(today, 2);
+
+    final starts = await _dataSource.upcomingActivityStarts(
+      rangeStart: today,
+      rangeEndExclusive: dayAfterTomorrow,
+    );
+    final ends = await _dataSource.upcomingDayEnds(
+      rangeStart: today,
+      rangeEndExclusive: dayAfterTomorrow,
+    );
+
+    await _localScheduler.reschedule(
+      starts: starts
+          .map((s) => (dayDateKey: s.dayDateKey, start: s.at))
+          .toList(),
+      ends: ends.map((e) => (dayDateKey: e.dayDateKey, end: e.end)).toList(),
+    );
+
+    _segmentTimerScheduler.reschedule(
+      starts: starts
+          .map(
+            (s) => (
+              eventId: s.dayDateKey,
+              scheduleId: 'start',
+              at: AppDateTime.toLocal(s.at),
+            ),
+          )
+          .toList(),
+      dayEnds: ends
+          .map(
+            (e) => (
+              eventId: e.dayDateKey,
+              at: AppDateTime.toLocal(e.end),
+            ),
+          )
+          .toList(),
+      onSegmentStart: (dayDateKey) {
+        unawaited(_activateForDay(dayDateKey));
+      },
+      onDayEnd: (dayDateKey) {
+        unawaited(_endForDay(dayDateKey));
+      },
+    );
+
+    await _reconcileActiveState();
+  }
+
+  Future<void> _reconcileActiveState() async {
+    if (_syncRunning) {
+      _syncAgain = true;
+      return;
+    }
+    _syncRunning = true;
+    try {
+      do {
+        _syncAgain = false;
+        await _reconcileActiveStateLocked();
+      } while (_syncAgain && _running);
+    } finally {
+      _syncRunning = false;
+    }
+  }
+
+  Future<void> _reconcileActiveStateLocked() async {
+    if (!_running) return;
+
+    final now = DateTime.now();
+    final today = AppDateTime.localDay(now);
+    final dayDateKey = timetableDayDateKey(today);
+    final customId = liveActivityCustomIdForTimetableDay(dayDateKey);
+
+    final snapshot = await _resolveSnapshot(day: today, now: now);
+    if (snapshot != null) {
+      await _applySnapshotIfNeeded(snapshot);
+      _activeCustomIds
+        ..clear()
+        ..add(customId);
+      return;
+    }
+
+    if (_activeCustomIds.contains(customId)) {
+      await _service.end(customId);
+      _activeCustomIds.remove(customId);
+      _lastContentFingerprint.remove(customId);
+    }
+  }
+
+  Future<void> _activateForDay(String dayDateKey) async {
+    if (_syncRunning) {
+      _syncAgain = true;
+      return;
+    }
+
+    final day = _parseDayDateKey(dayDateKey);
+    if (day == null) return;
+
+    final snapshot = await _resolveSnapshot(day: day);
+    if (snapshot == null) return;
+
+    await _applySnapshot(snapshot);
+    _activeCustomIds.add(snapshot.customId);
+    _lastContentFingerprint[snapshot.customId] = snapshot.contentFingerprint;
+  }
+
+  Future<void> _endForDay(String dayDateKey, {String? customId}) async {
+    final id = customId ?? liveActivityCustomIdForTimetableDay(dayDateKey);
+    await _service.end(id);
+    _activeCustomIds.remove(id);
+    _lastContentFingerprint.remove(id);
+  }
+
+  Future<void> _applySnapshotIfNeeded(
+    TimetableLiveActivitySnapshot snapshot,
+  ) async {
+    final lastFingerprint = _lastContentFingerprint[snapshot.customId];
+    if (_activeCustomIds.contains(snapshot.customId) &&
+        lastFingerprint == snapshot.contentFingerprint) {
+      return;
+    }
+    await _applySnapshot(snapshot);
+    _lastContentFingerprint[snapshot.customId] = snapshot.contentFingerprint;
+  }
+
+  Future<void> _applySnapshot(TimetableLiveActivitySnapshot snapshot) async {
+    final activitiesEnabled = await _service.areActivitiesEnabled();
+    if (!activitiesEnabled) return;
+    await _service.createOrUpdate(snapshot);
+  }
+
+  Future<TimetableLiveActivitySnapshot?> _resolveSnapshot({
+    required DateTime day,
+    DateTime? now,
+  }) async {
+    final entries = await _dataSource.entriesForDay(day);
+    final filters = _ref.read(calendarFiltersProvider);
+
+    await CalendarSignedUrlCache.shared.ensureLoaded();
+
+    return TimetableLiveActivityResolver.resolve(
+      day: day,
+      entries: entries,
+      filters: filters,
+      resolveAccent: (entry) => _resolveAccent(entry),
+      imageUrlForEntry: _peekMealImageUrl,
+      now: now,
+    );
+  }
+
+  Color _resolveAccent(CalendarEntry entry) {
+    if (entry.type == CalendarEntryType.lesson && entry.subjectId != null) {
+      final subjectOverrides =
+          _ref.read(subjectAccentOverridesProvider).value ??
+              const <String, Color>{};
+      final subjectOverride = subjectOverrides[entry.subjectId!];
+      if (subjectOverride != null) return subjectOverride;
+      return entry.accentColor;
+    }
+
+    final overrides = _ref.read(calendarAccentOverridesProvider);
+    return overrides[entry.type] ?? entry.accentColor;
+  }
+
+  String? _peekMealImageUrl(CalendarEntry entry) {
+    final urls = entry.imageUrls;
+    if (urls != null && urls.isNotEmpty) return urls.first;
+
+    final resolved = _imageUrlResolver.peekResolvedUrls(entry.imagePaths);
+    return resolved?.firstOrNull;
+  }
+
+  DateTime? _parseDayDateKey(String dayDateKey) {
+    final parts = dayDateKey.split('-');
+    if (parts.length != 3) return null;
+    final year = int.tryParse(parts[0]);
+    final month = int.tryParse(parts[1]);
+    final day = int.tryParse(parts[2]);
+    if (year == null || month == null || day == null) return null;
+    return DateTime(year, month, day);
+  }
+}
+
+final timetableLiveActivityCoordinatorProvider =
+    Provider<TimetableLiveActivityCoordinator>((ref) {
+  ref.keepAlive();
+  return TimetableLiveActivityCoordinator(
+    dataSource: TimetableLiveActivityDataSource(
+      ref.watch(calendarRepositoryProvider),
+    ),
+    service: TimetableLiveActivityService(),
+    localScheduler: TimetableLiveActivityLocalScheduler(),
+    segmentTimerScheduler: ScheduleSegmentTimerScheduler(),
+    imageUrlResolver: CalendarImageUrlResolver(
+      supabase: Supabase.instance.client,
+    ),
+    ref: ref,
+  );
+});

--- a/lib/features/calendar/timetable_live_activity/timetable_live_activity_constants.dart
+++ b/lib/features/calendar/timetable_live_activity/timetable_live_activity_constants.dart
@@ -1,0 +1,50 @@
+/// Vorlauf bis zum ersten Unterricht, ab dem die Live Activity startet.
+const int kTimetableLiveActivityPreStartMinutes = 15;
+
+/// App Group für iOS Live Activities (Runner + Widget Extension).
+const String kTimetableLiveActivityKind = 'timetable';
+
+/// Host für den Deep Link in den Tages-Stundenplan.
+const String kTimetableLiveActivityDeepLinkHost = 'timetable';
+
+/// Stable Activity-ID pro Kalendertag (lokales Datum yyyy-MM-dd).
+String liveActivityCustomIdForTimetableDay(String dayDateKey) =>
+    'timetable_$dayDateKey';
+
+/// Lokales Datum als Schlüssel (Europe/Berlin via [AppDateTime]).
+String timetableDayDateKey(DateTime localDay) {
+  final y = localDay.year.toString().padLeft(4, '0');
+  final m = localDay.month.toString().padLeft(2, '0');
+  final d = localDay.day.toString().padLeft(2, '0');
+  return '$y-$m-$d';
+}
+
+/// Deep Link, wenn die Nutzer:in die Stundenplan-Live Activity antippt.
+String timetableLiveActivityDeepLinkForDay(String dayDateKey) {
+  return 'chronoapp://$kTimetableLiveActivityDeepLinkHost'
+      '?date=${Uri.encodeQueryComponent(dayDateKey)}';
+}
+
+/// Liest den Tages-Schlüssel aus einem Stundenplan-Deep-Link.
+String? parseTimetableLiveActivityDayDateKey(Uri uri) {
+  final date = uri.queryParameters['date']?.trim();
+  if (date == null || date.isEmpty) return null;
+
+  if (uri.scheme == 'chronoapp' &&
+      uri.host == kTimetableLiveActivityDeepLinkHost) {
+    return date;
+  }
+
+  if (uri.path == '/timetable' || uri.path == 'timetable') {
+    return date;
+  }
+
+  if (uri.host == kTimetableLiveActivityDeepLinkHost && uri.path.isEmpty) {
+    return date;
+  }
+
+  return null;
+}
+
+bool isTimetableLiveActivityDeepLink(Uri uri) =>
+    parseTimetableLiveActivityDayDateKey(uri) != null;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -13,5 +13,8 @@ verify_jwt = true
 [functions.schedule-live-activity]
 verify_jwt = false
 
+[functions.timetable-live-activity]
+verify_jwt = false
+
 [functions.delete-account]
 verify_jwt = true

--- a/supabase/functions/_shared/fcm_v1.ts
+++ b/supabase/functions/_shared/fcm_v1.ts
@@ -127,10 +127,12 @@ export type LiveActivityFcmPayload = {
   platform: string;
   event: LiveActivityFcmEvent;
   activityId: string;
-  contentState: Record<string, string | number>;
+  contentState: Record<string, string | number | boolean>;
   liveActivityPushToken?: string | null;
   pushToStartToken?: string | null;
   eventId: string;
+  activityType?: string;
+  dayDate?: string;
 };
 
 export async function sendLiveActivityFcm(
@@ -143,15 +145,19 @@ export async function sendLiveActivityFcm(
   const nowSec = Math.floor(nowMs / 1000);
 
   const contentStateJson = JSON.stringify(payload.contentState);
+  const activityType = payload.activityType ?? "schedule_live_activity";
   const data: Record<string, string> = {
     timestamp: String(nowMs),
     event: payload.event,
     "content-state": contentStateJson,
     "activity-id": payload.activityId,
     activity_id: payload.activityId,
-    type: "schedule_live_activity",
+    type: activityType,
     event_id: payload.eventId,
   };
+  if (payload.dayDate) {
+    data.day_date = payload.dayDate;
+  }
 
   const message: Record<string, unknown> = {
     token: payload.token,
@@ -186,7 +192,10 @@ export async function sendLiveActivityFcm(
     message.apns = apns;
   } else {
     message.notification = {
-      title: String(payload.contentState.currentTitle ?? "Ablaufplan"),
+      title: String(
+        payload.contentState.currentTitle ??
+          (activityType === "timetable_live_activity" ? "Stundenplan" : "Ablaufplan"),
+      ),
       body: String(payload.contentState.currentSubtitle ?? ""),
     };
   }

--- a/supabase/functions/timetable-live-activity/index.ts
+++ b/supabase/functions/timetable-live-activity/index.ts
@@ -1,0 +1,433 @@
+/**
+ * Stundenplan-Live-Activity: Push-to-Start 15 min vor erster Stunde, Ende nach letztem Segment.
+ * Vollständiger Tagesplan liegt im Payload; Segmentwechsel laufen nativ auf dem Gerät.
+ *
+ * Cron: alle 15 Minuten (kein minütliches Polling).
+ * Change: DB-Trigger bei lesson/meal-Änderungen.
+ */
+
+import { createClient } from "npm:@supabase/supabase-js@2.49.1";
+import {
+  isUnregisteredTokenError,
+  parseServiceAccountJson,
+  sendLiveActivityFcm,
+  type LiveActivityFcmEvent,
+} from "../_shared/fcm_v1.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-cron-secret",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const SCHEDULE_TIMEZONE = "Europe/Berlin";
+const PRE_START_MINUTES = 15;
+const WINDOW_MS = 120_000;
+
+type DeviceRow = {
+  id: string;
+  user_id: string;
+  device_id: string;
+  fcm_token: string;
+  platform: string;
+  push_to_start_token: string | null;
+  live_activity_push_token: string | null;
+};
+
+type CalendarRow = {
+  id: string;
+  event_name: string | null;
+  type: string | null;
+  start_time: string;
+  end_time: string | null;
+  class: string | null;
+  diet: string | null;
+  image_paths: string | null;
+};
+
+type SeriesRow = {
+  id: string;
+  event_name: string | null;
+  type: string | null;
+  start_time: string;
+  end_time: string | null;
+  class: string | null;
+  diet: string | null;
+  series_start: string;
+  series_end: string | null;
+  subject_id: string | null;
+};
+
+type SubjectRow = {
+  id: string;
+  default_color: string | null;
+};
+
+type ChangeRequest = {
+  mode?: string;
+  source?: string;
+  op?: string;
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function localDateKey(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: SCHEDULE_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+function dayBoundsUtc(dayKey: string): { start: string; end: string } {
+  return {
+    start: `${dayKey}T00:00:00+02:00`,
+    end: `${dayKey}T23:59:59+02:00`,
+  };
+}
+
+function effectiveEnd(row: { start_time: string; end_time: string | null }): Date {
+  return new Date(row.end_time ?? row.start_time);
+}
+
+async function loadDevices(
+  supabase: ReturnType<typeof createClient>,
+): Promise<DeviceRow[]> {
+  const { data, error } = await supabase
+    .from("profile_push_devices")
+    .select(
+      "id, user_id, device_id, fcm_token, platform, push_to_start_token, live_activity_push_token",
+    )
+    .not("fcm_token", "is", null);
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as DeviceRow[];
+}
+
+async function wasDispatched(
+  supabase: ReturnType<typeof createClient>,
+  dayDate: string,
+  userId: string,
+  deviceId: string,
+  action: LiveActivityFcmEvent,
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("timetable_live_activity_dispatches")
+    .select("id")
+    .eq("day_date", dayDate)
+    .eq("user_id", userId)
+    .eq("device_id", deviceId)
+    .eq("action", action)
+    .maybeSingle();
+  return data != null;
+}
+
+async function markDispatched(
+  supabase: ReturnType<typeof createClient>,
+  dayDate: string,
+  userId: string,
+  deviceId: string,
+  action: LiveActivityFcmEvent,
+): Promise<void> {
+  await supabase.from("timetable_live_activity_dispatches").upsert({
+    day_date: dayDate,
+    user_id: userId,
+    device_id: deviceId,
+    action,
+    sent_at: new Date().toISOString(),
+  }, { onConflict: "day_date,user_id,device_id,action" });
+}
+
+function minimalContentState(dayDate: string): Record<string, string | number | boolean> {
+  return {
+    kind: "timetable",
+    dayDate,
+    segmentsJson: "[]",
+    activityStartMs: 0,
+    dayEndMs: 0,
+    remainingLessons: 0,
+    currentIndex: 0,
+    currentTitle: "Stundenplan",
+    currentSubtitle: "",
+    hasNext: false,
+    nextTitle: "",
+    nextSubtitle: "",
+    segmentStartMs: 0,
+    segmentEndMs: 0,
+    accentColor: "#124E30",
+    isMeal: false,
+    imageUrl: "",
+    eventId: dayDate,
+    isPreStart: false,
+  };
+}
+
+function resolveSegmentStartEvent(device: DeviceRow): LiveActivityFcmEvent {
+  const liveToken = device.live_activity_push_token?.trim();
+  return liveToken && liveToken.length > 0 ? "update" : "start";
+}
+
+async function sendForDevice(
+  supabase: ReturnType<typeof createClient>,
+  serviceAccount: ReturnType<typeof parseServiceAccountJson>,
+  device: DeviceRow,
+  dayDate: string,
+  fcmEvent: LiveActivityFcmEvent,
+  options?: { skipDedup?: boolean },
+): Promise<"sent" | "skipped" | "failed"> {
+  if (
+    !options?.skipDedup &&
+    await wasDispatched(supabase, dayDate, device.user_id, device.device_id, fcmEvent)
+  ) {
+    return "skipped";
+  }
+
+  const token = device.fcm_token?.trim();
+  if (!token) return "skipped";
+
+  const activityId = `timetable_${dayDate}`;
+  const contentState = minimalContentState(dayDate);
+  const result = await sendLiveActivityFcm(serviceAccount, {
+    token,
+    platform: device.platform,
+    event: fcmEvent,
+    activityId,
+    contentState,
+    eventId: dayDate,
+    dayDate,
+    activityType: "timetable_live_activity",
+    liveActivityPushToken: device.live_activity_push_token,
+    pushToStartToken: device.push_to_start_token,
+  });
+
+  if (result.ok) {
+    if (!options?.skipDedup) {
+      await markDispatched(
+        supabase,
+        dayDate,
+        device.user_id,
+        device.device_id,
+        fcmEvent,
+      );
+    }
+    return "sent";
+  }
+
+  if (isUnregisteredTokenError(result.errorCode)) {
+    await supabase.from("profile_push_devices").delete().eq("id", device.id);
+  }
+  return "failed";
+}
+
+async function loadTodaySchoolRows(
+  supabase: ReturnType<typeof createClient>,
+  dayKey: string,
+): Promise<CalendarRow[]> {
+  const bounds = dayBoundsUtc(dayKey);
+  const { data: events } = await supabase
+    .from("calendar_events")
+    .select("id, event_name, type, start_time, end_time, class, diet, image_paths")
+    .in("type", ["lesson", "meal"])
+    .gte("start_time", bounds.start)
+    .lte("start_time", bounds.end)
+    .order("start_time", { ascending: true });
+
+  return (events ?? []) as CalendarRow[];
+}
+
+async function handleCronTick(
+  supabase: ReturnType<typeof createClient>,
+  serviceAccount: ReturnType<typeof parseServiceAccountJson>,
+  now: Date,
+): Promise<Response> {
+  const dayKey = localDateKey(now);
+  const rows = await loadTodaySchoolRows(supabase, dayKey);
+  const lessons = rows.filter((r) => r.type === "lesson");
+  if (lessons.length === 0) {
+    return jsonResponse({ processed: 0, sent: 0, mode: "cron" });
+  }
+
+  const firstLessonStart = new Date(lessons[0].start_time);
+  const activityStart = new Date(
+    firstLessonStart.getTime() - PRE_START_MINUTES * 60_000,
+  );
+
+  const relevant = rows.filter((r) => r.type === "lesson" || r.type === "meal");
+  const lastEnd = relevant.reduce((max, row) => {
+    const end = effectiveEnd(row);
+    return end > max ? end : max;
+  }, effectiveEnd(relevant[0]));
+
+  const nowMs = now.getTime();
+  const shouldStart = Math.abs(nowMs - activityStart.getTime()) <= WINDOW_MS;
+  const shouldEnd = Math.abs(nowMs - lastEnd.getTime()) <= WINDOW_MS;
+
+  if (!shouldStart && !shouldEnd) {
+    return jsonResponse({ processed: 0, sent: 0, mode: "cron" });
+  }
+
+  let devices: DeviceRow[];
+  try {
+    devices = await loadDevices(supabase);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return jsonResponse({ error: "Query failed", detail: message }, 500);
+  }
+
+  let sent = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const device of devices) {
+    if (shouldStart) {
+      const fcmEvent = resolveSegmentStartEvent(device);
+      const result = await sendForDevice(
+        supabase,
+        serviceAccount,
+        device,
+        dayKey,
+        fcmEvent,
+      );
+      if (result === "sent") sent++;
+      else if (result === "failed") failed++;
+      else skipped++;
+    }
+
+    if (shouldEnd) {
+      const result = await sendForDevice(
+        supabase,
+        serviceAccount,
+        device,
+        dayKey,
+        "end",
+      );
+      if (result === "sent") sent++;
+      else if (result === "failed") failed++;
+      else skipped++;
+    }
+  }
+
+  return jsonResponse({
+    processed: 1,
+    sent,
+    failed,
+    skipped,
+    mode: "cron",
+    day_date: dayKey,
+    should_start: shouldStart,
+    should_end: shouldEnd,
+  });
+}
+
+async function handleContentChange(
+  supabase: ReturnType<typeof createClient>,
+  serviceAccount: ReturnType<typeof parseServiceAccountJson>,
+  now: Date,
+): Promise<Response> {
+  const dayKey = localDateKey(now);
+  const rows = await loadTodaySchoolRows(supabase, dayKey);
+  if (rows.length === 0) {
+    return jsonResponse({ processed: 1, sent: 0, skipped: 0, mode: "change" });
+  }
+
+  let devices: DeviceRow[];
+  try {
+    devices = await loadDevices(supabase);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return jsonResponse({ error: "Query failed", detail: message }, 500);
+  }
+
+  let sent = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const device of devices) {
+    const alreadyStarted = await wasDispatched(
+      supabase,
+      dayKey,
+      device.user_id,
+      device.device_id,
+      "start",
+    );
+    const fcmEvent: LiveActivityFcmEvent = alreadyStarted
+      ? "update"
+      : resolveSegmentStartEvent(device);
+
+    const result = await sendForDevice(
+      supabase,
+      serviceAccount,
+      device,
+      dayKey,
+      fcmEvent,
+      fcmEvent === "update" ? { skipDedup: true } : undefined,
+    );
+    if (result === "sent") sent++;
+    else if (result === "failed") failed++;
+    else skipped++;
+  }
+
+  return jsonResponse({
+    processed: 1,
+    sent,
+    failed,
+    skipped,
+    mode: "change",
+    day_date: dayKey,
+  });
+}
+
+Deno.serve(async (req) => {
+  try {
+    if (req.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders });
+    }
+    if (req.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed" }, 405);
+    }
+
+    const cronSecret = Deno.env.get("SCHEDULE_LIVE_ACTIVITY_CRON_SECRET");
+    const headerSecret = req.headers.get("x-cron-secret");
+    if (!cronSecret || headerSecret !== cronSecret) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    const serviceAccountRaw = Deno.env.get("FIREBASE_SERVICE_ACCOUNT_JSON");
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!serviceAccountRaw || !supabaseUrl || !serviceRoleKey) {
+      return jsonResponse({ error: "Server misconfigured" }, 500);
+    }
+
+    const serviceAccount = parseServiceAccountJson(serviceAccountRaw);
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const now = new Date();
+
+    let changeRequest: ChangeRequest = {};
+    try {
+      const rawBody = await req.text();
+      if (rawBody.trim().length > 0) {
+        changeRequest = JSON.parse(rawBody) as ChangeRequest;
+      }
+    } catch {
+      return jsonResponse({ error: "Invalid JSON body" }, 400);
+    }
+
+    if (changeRequest.mode === "change") {
+      return await handleContentChange(supabase, serviceAccount, now);
+    }
+
+    return await handleCronTick(supabase, serviceAccount, now);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error("timetable-live-activity unhandled", e);
+    return jsonResponse({ error: "Unhandled error", detail: message }, 500);
+  }
+});

--- a/supabase/migrations/20260702120000_timetable_live_activity.sql
+++ b/supabase/migrations/20260702120000_timetable_live_activity.sql
@@ -1,0 +1,118 @@
+-- Stundenplan-Live-Activity: Dispatch-Dedup, Trigger, Cron alle 15 Minuten
+
+CREATE TABLE IF NOT EXISTS public.timetable_live_activity_dispatches (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  day_date text NOT NULL,
+  user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  device_id text NOT NULL,
+  action text NOT NULL CHECK (action IN ('start', 'update', 'end')),
+  sent_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (day_date, user_id, device_id, action)
+);
+
+CREATE INDEX IF NOT EXISTS timetable_live_activity_dispatches_sent_at_idx
+  ON public.timetable_live_activity_dispatches (sent_at);
+
+ALTER TABLE public.timetable_live_activity_dispatches ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.timetable_live_activity_dispatches IS
+  'Dedup für serverseitige Stundenplan-Live-Activity FCM (nur service_role).';
+
+CREATE OR REPLACE FUNCTION public.trigger_timetable_live_activity_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  cron_secret text;
+  row_type text;
+BEGIN
+  IF TG_TABLE_NAME = 'calendar_events' THEN
+    row_type := COALESCE(
+      CASE WHEN TG_OP = 'DELETE' THEN OLD.type ELSE NEW.type END,
+      ''
+    );
+  ELSIF TG_TABLE_NAME = 'calendar_series' THEN
+    row_type := COALESCE(
+      CASE WHEN TG_OP = 'DELETE' THEN OLD.type ELSE NEW.type END,
+      ''
+    );
+  ELSE
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  IF row_type NOT IN ('lesson', 'meal') THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  SELECT decrypted_secret INTO cron_secret
+  FROM vault.decrypted_secrets
+  WHERE name = 'schedule_live_activity_cron_secret'
+  LIMIT 1;
+
+  IF cron_secret IS NULL OR cron_secret = '' THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  PERFORM net.http_post(
+    url := 'https://chrbvfaknykaycwumuba.supabase.co/functions/v1/timetable-live-activity',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', cron_secret
+    ),
+    body := jsonb_build_object(
+      'mode', 'change',
+      'op', TG_OP,
+      'source', TG_TABLE_NAME
+    )
+  );
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+COMMENT ON FUNCTION public.trigger_timetable_live_activity_change() IS
+  'Ruft timetable-live-activity bei Stunden-/Essens-Änderungen auf.';
+
+DROP TRIGGER IF EXISTS timetable_live_activity_calendar_events_change
+  ON public.calendar_events;
+CREATE TRIGGER timetable_live_activity_calendar_events_change
+  AFTER INSERT OR UPDATE OR DELETE ON public.calendar_events
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trigger_timetable_live_activity_change();
+
+DROP TRIGGER IF EXISTS timetable_live_activity_calendar_series_change
+  ON public.calendar_series;
+CREATE TRIGGER timetable_live_activity_calendar_series_change
+  AFTER INSERT OR UPDATE OR DELETE ON public.calendar_series
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trigger_timetable_live_activity_change();
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'timetable-live-activity') THEN
+    PERFORM cron.unschedule(jobid)
+    FROM cron.job
+    WHERE jobname = 'timetable-live-activity';
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'timetable-live-activity',
+  '*/15 * * * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://chrbvfaknykaycwumuba.supabase.co/functions/v1/timetable-live-activity',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', coalesce(
+        (SELECT decrypted_secret FROM vault.decrypted_secrets
+         WHERE name = 'schedule_live_activity_cron_secret' LIMIT 1),
+        ''
+      )
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);

--- a/test/features/calendar/timetable_live_activity/timetable_live_activity_logic_test.dart
+++ b/test/features/calendar/timetable_live_activity/timetable_live_activity_logic_test.dart
@@ -1,0 +1,146 @@
+import 'package:chronoapp/core/database/backend_enums.dart';
+import 'package:chronoapp/features/calendar/domain/filter/calendar_filters_state.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart';
+import 'package:chronoapp/features/calendar/timetable_live_activity/timetable_live_activity_constants.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TimetableLiveActivityResolver', () {
+    const filters = CalendarFiltersState();
+
+    CalendarEntry lesson({
+      required String id,
+      required DateTime start,
+      required Duration duration,
+      String name = 'Mathe',
+      Color color = const Color(0xFF124E30),
+    }) {
+      return CalendarEntry(
+        id: id,
+        eventName: name,
+        startTime: start,
+        endTime: start.add(duration),
+        accentColor: color,
+        type: CalendarEntryType.lesson,
+        subjectId: 'sub-1',
+        choir: BackendChoir.unknown,
+        voice: BackendVoice.unknown,
+        schoolTrack: BackendSchoolTrack.unknown,
+        diet: BackendDiet.unknown,
+      );
+    }
+
+    CalendarEntry lunch({
+      required String id,
+      required DateTime start,
+      required Duration duration,
+    }) {
+      return CalendarEntry(
+        id: id,
+        eventName: 'Mittagessen',
+        startTime: start,
+        endTime: start.add(duration),
+        accentColor: const Color(0xFF124E30),
+        type: CalendarEntryType.meal,
+        choir: BackendChoir.unknown,
+        voice: BackendVoice.unknown,
+        schoolTrack: BackendSchoolTrack.unknown,
+        diet: BackendDiet.noRestriction,
+      );
+    }
+
+    test('startet 15 min vor erster Stunde mit vollem Tagesplan', () {
+      final day = DateTime(2026, 7, 2);
+      final firstStart = DateTime(2026, 7, 2, 8, 0);
+      final entries = [
+        lesson(id: 'l1', start: firstStart, duration: const Duration(hours: 1)),
+        lunch(
+          id: 'm1',
+          start: DateTime(2026, 7, 2, 12, 0),
+          duration: const Duration(minutes: 45),
+        ),
+        lesson(
+          id: 'l2',
+          start: DateTime(2026, 7, 2, 13, 0),
+          duration: const Duration(hours: 1),
+        ),
+      ];
+
+      final preStart = DateTime(2026, 7, 2, 7, 45);
+      final snapshot = TimetableLiveActivityResolver.resolve(
+        day: day,
+        entries: entries,
+        filters: filters,
+        resolveAccent: (e) => e.accentColor,
+        now: preStart,
+      );
+
+      expect(snapshot, isNotNull);
+      expect(snapshot!.segments.length, 3);
+      expect(snapshot.isPreStart, isTrue);
+      expect(snapshot.currentTitle, 'Mathe');
+      expect(snapshot.remainingLessons, 2);
+      expect(snapshot.customId, liveActivityCustomIdForTimetableDay('2026-07-02'));
+      expect(snapshot.toActivityPayload()['kind'], kTimetableLiveActivityKind);
+    });
+
+    test('wechselt nativ zur Mittagspause mit zwei verbleibenden Stunden', () {
+      final day = DateTime(2026, 7, 2);
+      final entries = [
+        lesson(
+          id: 'l1',
+          start: DateTime(2026, 7, 2, 8, 0),
+          duration: const Duration(hours: 1),
+        ),
+        lunch(
+          id: 'm1',
+          start: DateTime(2026, 7, 2, 12, 0),
+          duration: const Duration(minutes: 45),
+        ),
+        lesson(
+          id: 'l2',
+          start: DateTime(2026, 7, 2, 13, 0),
+          duration: const Duration(hours: 1),
+        ),
+      ];
+
+      final snapshot = TimetableLiveActivityResolver.resolve(
+        day: day,
+        entries: entries,
+        filters: filters,
+        resolveAccent: (e) => e.accentColor,
+        now: DateTime(2026, 7, 2, 12, 10),
+      );
+
+      expect(snapshot, isNotNull);
+      expect(snapshot!.isMeal, isTrue);
+      expect(snapshot.currentTitle, 'Mittagessen');
+      expect(snapshot.remainingLessons, 1);
+      expect(snapshot.hasNext, isTrue);
+      expect(snapshot.nextTitle, 'Mathe');
+    });
+
+    test('liefert null nach Tagesende', () {
+      final day = DateTime(2026, 7, 2);
+      final entries = [
+        lesson(
+          id: 'l1',
+          start: DateTime(2026, 7, 2, 8, 0),
+          duration: const Duration(hours: 1),
+        ),
+      ];
+
+      final snapshot = TimetableLiveActivityResolver.resolve(
+        day: day,
+        entries: entries,
+        filters: filters,
+        resolveAccent: (e) => e.accentColor,
+        now: DateTime(2026, 7, 2, 9, 5),
+      );
+
+      expect(snapshot, isNull);
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Neue Live Activity für den Schultagesplan (Unterrichtsstunden + Mittagessen), orientiert am bestehenden Ablaufplan-Design (Konzert), aber mit dezenter Fachfarbe und nativer Tages-Zeitleiste.

## Architektur-Plan (umgesetzt)

```mermaid
flowchart TB
  subgraph client [Flutter App]
    Coord[TimetableLiveActivityCoordinator]
    Resolver[TimetableLiveActivityResolver]
    Payload["segmentsJson (voller Tag)"]
    Timers[Lokale Timer + Notifications]
  end

  subgraph native [Native UI]
    iOS["iOS TimelineView → Segmentwechsel"]
    Android["Android Chronometer + segmentsJson"]
  end

  subgraph backend [Supabase]
    Trigger[DB-Trigger lesson/meal]
    Cron["pg_cron alle 15 min"]
    EF[timetable-live-activity]
  end

  Timers --> Coord
  Coord --> Resolver --> Payload --> native
  Trigger --> EF
  Cron --> EF
  EF -->|FCM start/update/end| Coord
```

### Kernentscheidungen

| Aspekt | Lösung |
|--------|--------|
| **Startzeitpunkt** | 15 min vor erster Unterrichtsstunde |
| **Segmentwechsel** | Nativ auf dem Gerät aus `segmentsJson` – kein Server-Push pro Stunde |
| **Payload** | Kompletter Tagesplan (Stunden + Mittagessen) inkl. Farbe, Zeiten, Bild-URL |
| **Design** | Gleiches Layout wie Ablaufplan; Fachfarbe nur in der Fortschrittsleiste |
| **Mittagessen** | Kleines Thumbnail (iOS `AsyncImage`, Android `setImageViewUri`) |
| **Verbleibend** | „Noch X Stunden" = verbleibende Unterrichtseinheiten |
| **Backend** | Event-getriggert (DB-Trigger) + Cron **alle 15 Minuten** (kein minütliches Polling) nur für Start/Ende |

## Änderungen

### Flutter (`lib/features/calendar/timetable_live_activity/`)
- Domain: `TimetableLiveActivitySegment`, `Snapshot`, `Resolver`
- Coordinator mit PowerSync-Watch, Filtern, Akzentfarben, Meal-Bild-URLs
- Lokale Notifications + Einmal-Timer für Tagesstart/-ende
- Integration in Bootstrap, FCM, Deep Links (`chronoapp://timetable?date=…`)

### iOS
- `TimetableLiveData` parst `segmentsJson` und löst aktuelles Segment per `TimelineView` auf
- Akzentfarbene Fortschrittsleiste, Meal-Thumbnail, Stunden-Zähler

### Android
- `ChronoLiveActivityManager` erweitert für `kind=timetable` mit nativer Segmentauflösung

### Supabase
- Edge Function `timetable-live-activity`
- Migration: `timetable_live_activity_dispatches`, Trigger, 15-Min-Cron
- FCM-Helper unterstützt `timetable_live_activity` als Typ

## Tests

- `test/features/calendar/timetable_live_activity/timetable_live_activity_logic_test.dart` (3 Tests, grün)

## Deployment-Hinweise

1. Migration `20260702120000_timetable_live_activity.sql` anwenden
2. Edge Function `timetable-live-activity` deployen
3. Bestehendes Vault-Secret `schedule_live_activity_cron_secret` wird wiederverwendet
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20a8d8e7-9905-41ae-9e48-83918f68fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20a8d8e7-9905-41ae-9e48-83918f68fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

