### PR TITLE
Stundenplan-Live-Activity: UI-Fixes + Event-Hintergrund schwarz

### DIFF
--- a/android/app/src/main/kotlin/com/domspatzen/chronoapp/ChronoLiveActivityManager.kt
+++ b/android/app/src/main/kotlin/com/domspatzen/chronoapp/ChronoLiveActivityManager.kt
@@ -31,24 +31,36 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
         val id: String,
         val type: String,
         val title: String,
+        val shortTitle: String?,
         val subtitle: String,
         val startMs: Long,
         val endMs: Long,
         val accentColor: String,
         val imageUrl: String?,
-    )
+    ) {
+        fun displayShortTitle(): String {
+            val trimmed = shortTitle?.trim().orEmpty()
+            if (trimmed.isNotEmpty()) return trimmed
+            val titleTrimmed = title.trim()
+            if (titleTrimmed.length <= 3) return titleTrimmed
+            return titleTrimmed.take(3)
+        }
+    }
 
     private data class ResolvedSegment(
         val title: String,
         val subtitle: String,
+        val shortTitle: String,
         val segmentStartMs: Long,
         val segmentEndMs: Long,
         val hasNext: Boolean,
         val nextTitle: String,
         val nextSubtitle: String,
+        val nextShortTitle: String,
         val remainingLessons: Int,
         val isMeal: Boolean,
         val imageUrl: String?,
+        val isPreStart: Boolean,
     )
 
     private fun pendingIntentForSchedule(eventId: String): PendingIntent {
@@ -142,6 +154,7 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
                             id = obj.optString("id"),
                             type = obj.optString("type"),
                             title = obj.optString("title"),
+                            shortTitle = obj.optString("shortTitle").ifBlank { null },
                             subtitle = obj.optString("subtitle"),
                             startMs = obj.optLong("startMs"),
                             endMs = obj.optLong("endMs"),
@@ -168,14 +181,17 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
             return ResolvedSegment(
                 title = first.title,
                 subtitle = first.subtitle,
+                shortTitle = first.displayShortTitle(),
                 segmentStartMs = activityStartMs,
                 segmentEndMs = first.startMs,
                 hasNext = next != null,
                 nextTitle = next?.title ?: "",
                 nextSubtitle = next?.subtitle ?: "",
+                nextShortTitle = next?.displayShortTitle() ?: "",
                 remainingLessons = remainingLessonCount(segments, 0, nowMs),
                 isMeal = first.type == "meal",
                 imageUrl = first.imageUrl,
+                isPreStart = true,
             )
         }
 
@@ -185,14 +201,17 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
                 return ResolvedSegment(
                     title = segment.title,
                     subtitle = segment.subtitle,
+                    shortTitle = segment.displayShortTitle(),
                     segmentStartMs = segment.startMs,
                     segmentEndMs = segment.endMs,
                     hasNext = next != null,
                     nextTitle = next?.title ?: "",
                     nextSubtitle = next?.subtitle ?: "",
+                    nextShortTitle = next?.displayShortTitle() ?: "",
                     remainingLessons = remainingLessonCount(segments, index, nowMs),
                     isMeal = segment.type == "meal",
                     imageUrl = segment.imageUrl,
+                    isPreStart = false,
                 )
             }
         }
@@ -218,6 +237,13 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
         return if (count == 1) "Noch 1 Stunde" else "Noch $count Stunden"
     }
 
+    private fun compactLeadingLabel(resolved: ResolvedSegment): String {
+        return when {
+            resolved.isPreStart || !resolved.hasNext -> resolved.shortTitle
+            else -> resolved.nextShortTitle
+        }.ifBlank { "—" }
+    }
+
     private fun updateRemoteViews(views: RemoteViews, data: Map<String, Any>, expanded: Boolean) {
         applyThemeColors(views, expanded)
         val kind = data["kind"] as? String ?: "schedule"
@@ -230,17 +256,10 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
                 ?: now
             val resolved = resolveTimetable(segments, activityStartMs, now) ?: return
 
-            val subtitle = buildString {
-                if (resolved.remainingLessons > 0) {
-                    append(remainingLessonsLabel(resolved.remainingLessons))
-                }
-                if (resolved.subtitle.isNotBlank()) {
-                    if (isNotEmpty()) append(" · ")
-                    append(resolved.subtitle)
-                }
-            }
-
-            views.setTextViewText(R.id.current_title, resolved.title)
+            views.setTextViewText(
+                R.id.current_title,
+                if (expanded) resolved.title else compactLeadingLabel(resolved),
+            )
             applyCountdownChronometer(views, resolved.segmentEndMs)
 
             if (resolved.isMeal && !resolved.imageUrl.isNullOrBlank() && expanded) {
@@ -267,7 +286,7 @@ class ChronoLiveActivityManager(context: Context) : LiveActivityManager(context)
 
             if (!expanded) return
 
-            setTextOrHide(views, R.id.current_subtitle, subtitle)
+            setTextOrHide(views, R.id.current_subtitle, resolved.subtitle)
             if (!resolved.isMeal) {
                 if (resolved.hasNext) {
                     views.setViewVisibility(R.id.next_column, View.VISIBLE)

--- a/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
+++ b/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
@@ -766,6 +766,32 @@ private struct ScheduleLiveActivityLockScreenGlassBackground: View {
   }
 }
 
+/// Event-Ablaufplan: schwarze Fläche mit Liquid-Glass-Rand (Lockscreen).
+@available(iOSApplicationExtension 16.1, *)
+private struct ScheduleEventLiveActivityLockScreenBackground: View {
+  private let cornerRadius: CGFloat = 22
+
+  var body: some View {
+    if #available(iOSApplicationExtension 26.0, *) {
+      RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color.black)
+        .padding(1.5)
+        .background {
+          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(.clear)
+            .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+        }
+    } else {
+      RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color.black)
+        .overlay {
+          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .stroke(Color.white.opacity(0.14), lineWidth: 0.5)
+        }
+    }
+  }
+}
+
 @available(iOSApplicationExtension 16.1, *)
 private struct ScheduleLiveActivityLockScreenView: View {
   let data: ScheduleLiveData
@@ -775,7 +801,7 @@ private struct ScheduleLiveActivityLockScreenView: View {
     ScheduleLiveActivityView(data: data, layout: .lockScreen)
       .background {
         if showsWidgetContainerBackground {
-          ScheduleLiveActivityLockScreenGlassBackground()
+          ScheduleEventLiveActivityLockScreenBackground()
             .ignoresSafeArea()
         }
       }
@@ -806,7 +832,7 @@ struct ChronoScheduleLiveActivity: Widget {
         let data = ScheduleLiveData(context: context)
         ScheduleLiveActivityLockScreenView(data: data)
           .widgetURL(scheduleDeepLink(for: data.eventId))
-          .activityBackgroundTint(.clear)
+          .activityBackgroundTint(.black)
           .activitySystemActionForegroundColor(.white)
       }
     } dynamicIsland: { context in

--- a/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
+++ b/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
@@ -101,17 +101,27 @@ private struct TimetableSegment: Codable {
   let id: String
   let type: String
   let title: String
+  let shortTitle: String?
   let subtitle: String
   let startMs: Double
   let endMs: Double
   let accentColor: String
   let imageUrl: String?
+
+  var displayShortTitle: String {
+    let trimmed = (shortTitle ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmed.isEmpty { return trimmed }
+    let titleTrimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard titleTrimmed.count > 3 else { return titleTrimmed }
+    return String(titleTrimmed.prefix(3))
+  }
 }
 
 private struct TimetableResolvedSegment {
   let index: Int
   let title: String
   let subtitle: String
+  let currentShortTitle: String
   let segmentStart: Date
   let segmentEnd: Date
   let accentColor: Color
@@ -120,6 +130,7 @@ private struct TimetableResolvedSegment {
   let hasNext: Bool
   let nextTitle: String
   let nextSubtitle: String
+  let nextShortTitle: String
   let remainingLessons: Int
   let isPreStart: Bool
 }
@@ -156,6 +167,7 @@ private struct TimetableLiveData {
         index: 0,
         title: first.title,
         subtitle: first.subtitle,
+        currentShortTitle: first.displayShortTitle,
         segmentStart: activityStart,
         segmentEnd: Date(timeIntervalSince1970: first.startMs / 1000),
         accentColor: parseHexColor(first.accentColor),
@@ -164,6 +176,7 @@ private struct TimetableLiveData {
         hasNext: next != nil,
         nextTitle: next?.title ?? "",
         nextSubtitle: next?.subtitle ?? "",
+        nextShortTitle: next?.displayShortTitle ?? "",
         remainingLessons: remainingLessonCount(fromIndex: 0, nowMs: nowMs),
         isPreStart: true
       )
@@ -176,6 +189,7 @@ private struct TimetableLiveData {
           index: index,
           title: segment.title,
           subtitle: segment.subtitle,
+          currentShortTitle: segment.displayShortTitle,
           segmentStart: Date(timeIntervalSince1970: segment.startMs / 1000),
           segmentEnd: Date(timeIntervalSince1970: segment.endMs / 1000),
           accentColor: parseHexColor(segment.accentColor),
@@ -184,6 +198,7 @@ private struct TimetableLiveData {
           hasNext: next != nil,
           nextTitle: next?.title ?? "",
           nextSubtitle: next?.subtitle ?? "",
+          nextShortTitle: next?.displayShortTitle ?? "",
           remainingLessons: remainingLessonCount(fromIndex: index, nowMs: nowMs),
           isPreStart: false
         )
@@ -373,40 +388,64 @@ private struct TimetableMealThumbnail: View {
 }
 
 @available(iOSApplicationExtension 16.1, *)
+private struct TimetableCountdownText: View {
+  let segmentStart: Date
+  let segmentEnd: Date
+  var fontSize: CGFloat = 13
+  var fontWeight: Font.Weight = .regular
+
+  var body: some View {
+    Group {
+      if segmentEnd > segmentStart {
+        (Text("Noch ")
+          + Text(
+            timerInterval: segmentStart...segmentEnd,
+            countsDown: true,
+            showsHours: false
+          ))
+      } else {
+        Text("Noch 0:00")
+      }
+    }
+    .font(.system(size: fontSize, weight: fontWeight).monospacedDigit())
+    .foregroundColor(.white)
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
 private struct TimetableProgressSection: View {
   let segmentStart: Date
   let segmentEnd: Date
   let accentColor: Color
+  let now: Date
   var timeFontSize: CGFloat = 13
   var barOuterHeight: CGFloat = 15
 
   var body: some View {
-    VStack(spacing: 8) {
+    VStack(spacing: 6) {
       HStack {
         Text(formatTime(segmentStart))
           .font(.system(size: timeFontSize, weight: .regular))
           .foregroundColor(.white)
         Spacer()
-        TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
-          Text("Noch \(formatCountdown(seconds: remainingSeconds(until: segmentEnd, now: timeline.date)))")
-            .font(.system(size: timeFontSize, weight: .regular).monospacedDigit())
-            .foregroundColor(.white)
-        }
+        TimetableCountdownText(
+          segmentStart: segmentStart,
+          segmentEnd: segmentEnd,
+          fontSize: timeFontSize
+        )
         Spacer()
         Text(formatTime(segmentEnd))
           .font(.system(size: timeFontSize, weight: .regular))
           .foregroundColor(.white)
       }
-      TimelineView(.periodic(from: segmentStart, by: 1.0)) { timeline in
-        let total = segmentEnd.timeIntervalSince(segmentStart)
-        let elapsed = timeline.date.timeIntervalSince(segmentStart)
-        let p = total > 0 ? min(max(elapsed / total, 0), 1) : 1
-        TimetableAccentProgressBar(
-          progress: p,
-          accentColor: accentColor,
-          outerHeight: barOuterHeight
-        )
-      }
+      let total = segmentEnd.timeIntervalSince(segmentStart)
+      let elapsed = now.timeIntervalSince(segmentStart)
+      let p = total > 0 ? min(max(elapsed / total, 0), 1) : 1
+      TimetableAccentProgressBar(
+        progress: p,
+        accentColor: accentColor,
+        outerHeight: barOuterHeight
+      )
     }
   }
 }
@@ -415,12 +454,13 @@ private struct TimetableProgressSection: View {
 private struct TimetableLiveActivityView: View {
   let data: TimetableLiveData
   let layout: ScheduleLiveActivityLayout
+  var showsRemainingLessons: Bool = true
 
   var body: some View {
     TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
       if let resolved = data.resolve(at: timeline.date) {
         VStack(alignment: .leading, spacing: layout.sectionSpacing) {
-          HStack(alignment: .center, spacing: layout.columnSpacing) {
+          HStack(alignment: .top, spacing: layout.columnSpacing) {
             ScheduleColumn(
               title: resolved.title,
               subtitle: resolved.subtitle,
@@ -430,12 +470,13 @@ private struct TimetableLiveActivityView: View {
             )
             if resolved.isMeal, let imageUrl = resolved.imageUrl, !imageUrl.isEmpty {
               TimetableMealThumbnail(imageUrl: imageUrl)
-                .frame(width: 34)
+                .frame(width: 30)
             } else if resolved.hasNext {
               Image(systemName: "arrow.right")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(Color(red: 0.54, green: 0.54, blue: 0.54))
-                .frame(width: 20)
+                .frame(width: 16)
+                .padding(.top, 2)
               ScheduleColumn(
                 title: resolved.nextTitle,
                 subtitle: resolved.nextSubtitle,
@@ -446,7 +487,7 @@ private struct TimetableLiveActivityView: View {
             }
           }
 
-          if resolved.remainingLessons > 0 {
+          if showsRemainingLessons && resolved.remainingLessons > 0 {
             Text(remainingLessonsLabel(resolved.remainingLessons))
               .font(.system(size: layout.timeFontSize, weight: .medium))
               .foregroundColor(Color(red: 0.67, green: 0.67, blue: 0.67))
@@ -456,16 +497,91 @@ private struct TimetableLiveActivityView: View {
             segmentStart: resolved.segmentStart,
             segmentEnd: resolved.segmentEnd,
             accentColor: resolved.accentColor,
+            now: timeline.date,
             timeFontSize: layout.timeFontSize,
             barOuterHeight: layout.barOuterHeight
           )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, layout.horizontalPadding)
-        .padding(.vertical, layout.verticalPadding)
+        .padding(.top, layout.topPadding)
+        .padding(.bottom, layout.bottomPadding)
       }
     }
   }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+private struct TimetableDynamicIslandHeaderView: View {
+  let data: TimetableLiveData
+  let layout: ScheduleLiveActivityLayout
+
+  var body: some View {
+    TimelineView(.periodic(from: .now, by: 30.0)) { timeline in
+      if let resolved = data.resolve(at: timeline.date) {
+        HStack(alignment: .top, spacing: layout.columnSpacing) {
+          ScheduleColumn(
+            title: resolved.title,
+            subtitle: resolved.subtitle,
+            alignment: .leading,
+            titleSize: layout.titleSize,
+            subtitleSize: layout.subtitleSize
+          )
+          if resolved.isMeal, let imageUrl = resolved.imageUrl, !imageUrl.isEmpty {
+            Spacer(minLength: 0)
+            TimetableMealThumbnail(imageUrl: imageUrl)
+          } else if resolved.hasNext {
+            Spacer(minLength: 0)
+            Image(systemName: "arrow.right")
+              .font(.system(size: 10, weight: .semibold))
+              .foregroundColor(Color(red: 0.54, green: 0.54, blue: 0.54))
+              .padding(.top, 2)
+            ScheduleColumn(
+              title: resolved.nextTitle,
+              subtitle: resolved.nextSubtitle,
+              alignment: .trailing,
+              titleSize: layout.titleSize,
+              subtitleSize: layout.subtitleSize
+            )
+          }
+        }
+        .padding(.horizontal, layout.horizontalPadding)
+      }
+    }
+  }
+}
+
+@available(iOSApplicationExtension 16.1, *)
+private struct TimetableDynamicIslandBottomView: View {
+  let data: TimetableLiveData
+  let layout: ScheduleLiveActivityLayout
+
+  var body: some View {
+    TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
+      if let resolved = data.resolve(at: timeline.date) {
+        TimetableProgressSection(
+          segmentStart: resolved.segmentStart,
+          segmentEnd: resolved.segmentEnd,
+          accentColor: resolved.accentColor,
+          now: timeline.date,
+          timeFontSize: layout.timeFontSize,
+          barOuterHeight: layout.barOuterHeight
+        )
+        .padding(.horizontal, layout.horizontalPadding)
+        .padding(.bottom, layout.bottomPadding)
+      }
+    }
+  }
+}
+
+private func timetableCompactLeadingLabel(
+  for resolved: TimetableResolvedSegment?
+) -> String {
+  guard let resolved else { return "—" }
+  if resolved.isPreStart || !resolved.hasNext {
+    return resolved.currentShortTitle
+  }
+  return resolved.nextShortTitle
 }
 
 @available(iOSApplicationExtension 16.1, *)
@@ -474,7 +590,7 @@ private struct TimetableLiveActivityLockScreenView: View {
   @Environment(\.showsWidgetContainerBackground) private var showsWidgetContainerBackground
 
   var body: some View {
-    TimetableLiveActivityView(data: data, layout: .lockScreen)
+    TimetableLiveActivityView(data: data, layout: .timetableLockScreen)
       .background {
         if showsWidgetContainerBackground {
           ScheduleLiveActivityLockScreenGlassBackground()
@@ -529,6 +645,8 @@ private struct ScheduleLiveActivityLayout {
   let barOuterHeight: CGFloat
   let horizontalPadding: CGFloat
   let verticalPadding: CGFloat
+  let topPadding: CGFloat
+  let bottomPadding: CGFloat
   let showsBackground: Bool
 
   static let lockScreen = ScheduleLiveActivityLayout(
@@ -540,6 +658,22 @@ private struct ScheduleLiveActivityLayout {
     barOuterHeight: 15,
     horizontalPadding: 30,
     verticalPadding: 32,
+    topPadding: 32,
+    bottomPadding: 32,
+    showsBackground: false
+  )
+
+  static let timetableLockScreen = ScheduleLiveActivityLayout(
+    sectionSpacing: 16,
+    columnSpacing: 14,
+    titleSize: 19,
+    subtitleSize: 15,
+    timeFontSize: 15,
+    barOuterHeight: 14,
+    horizontalPadding: 28,
+    verticalPadding: 24,
+    topPadding: 28,
+    bottomPadding: 22,
     showsBackground: false
   )
 
@@ -555,6 +689,22 @@ private struct ScheduleLiveActivityLayout {
     barOuterHeight: 12,
     horizontalPadding: 10,
     verticalPadding: 6,
+    topPadding: 6,
+    bottomPadding: 6,
+    showsBackground: false
+  )
+
+  static let timetableDynamicIsland = ScheduleLiveActivityLayout(
+    sectionSpacing: 8,
+    columnSpacing: 10,
+    titleSize: 15,
+    subtitleSize: 12,
+    timeFontSize: 11,
+    barOuterHeight: 8,
+    horizontalPadding: 4,
+    verticalPadding: 2,
+    topPadding: 0,
+    bottomPadding: 2,
     showsBackground: false
   )
 }
@@ -664,25 +814,34 @@ struct ChronoScheduleLiveActivity: Widget {
       if kind == "timetable" {
         let data = TimetableLiveData(context: context)
         return DynamicIsland {
+          DynamicIslandExpandedRegion(.center) {
+            TimetableDynamicIslandHeaderView(data: data, layout: .timetableDynamicIsland)
+          }
           DynamicIslandExpandedRegion(.bottom) {
-            TimetableLiveActivityView(data: data, layout: .dynamicIsland)
+            TimetableDynamicIslandBottomView(data: data, layout: .timetableDynamicIsland)
           }
         } compactLeading: {
-          TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
-            if let resolved = data.resolve(at: timeline.date) {
-              Text(formatTime(resolved.segmentEnd))
+          TimelineView(.periodic(from: .now, by: 30.0)) { timeline in
+            let resolved = data.resolve(at: timeline.date)
+            Text(timetableCompactLeadingLabel(for: resolved))
+              .font(.footnote.weight(.semibold))
+              .foregroundColor(.white)
+              .lineLimit(1)
+              .minimumScaleFactor(0.75)
+          }
+        } compactTrailing: {
+          TimelineView(.periodic(from: .now, by: 30.0)) { timeline in
+            if let resolved = data.resolve(at: timeline.date),
+               resolved.segmentEnd > resolved.segmentStart {
+              Text(
+                timerInterval: resolved.segmentStart...resolved.segmentEnd,
+                countsDown: true,
+                showsHours: false
+              )
                 .font(.footnote.monospacedDigit().weight(.semibold))
                 .foregroundColor(.white)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
-            }
-          }
-        } compactTrailing: {
-          TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
-            if let resolved = data.resolve(at: timeline.date) {
-              Text(formatCountdown(seconds: remainingSeconds(until: resolved.segmentEnd, now: timeline.date)))
-                .font(.footnote.monospacedDigit().weight(.semibold))
-                .foregroundColor(.white)
             }
           }
         } minimal: {

--- a/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart
+++ b/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart
@@ -5,6 +5,7 @@ import 'package:chronoapp/features/calendar/domain/meal_period.dart';
 import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
 import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_segment.dart';
 import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_snapshot.dart';
+import 'package:chronoapp/features/calendar/presentation/helpers/lesson_week_grid_display_name.dart';
 import 'package:chronoapp/features/calendar/timetable_live_activity/timetable_live_activity_constants.dart';
 import 'package:flutter/material.dart';
 
@@ -183,15 +184,14 @@ abstract final class TimetableLiveActivityResolver {
     final start = AppDateTime.toLocal(entry.startTime);
     final end = AppDateTime.toLocal(entry.endTime);
     final subtitle = entry.type == CalendarEntryType.lesson
-        ? (entry.className?.trim().isNotEmpty == true
-            ? entry.className!.trim()
-            : entry.location?.trim() ?? '')
+        ? (entry.location?.trim() ?? '')
         : '';
 
     return TimetableLiveActivitySegment(
       id: entry.id,
       type: entry.type,
       title: entry.eventName,
+      shortTitle: _shortTitleForEntry(entry),
       subtitle: subtitle,
       startMs: start.millisecondsSinceEpoch,
       endMs: end.millisecondsSinceEpoch,
@@ -235,6 +235,13 @@ abstract final class TimetableLiveActivityResolver {
     }
 
     return null;
+  }
+
+  static String _shortTitleForEntry(CalendarEntry entry) {
+    if (entry.type == CalendarEntryType.meal) return 'Essen';
+    final display = lessonWeekGridDisplayName(entry.eventName);
+    if (display.length <= 3) return display;
+    return display.substring(0, 3);
   }
 
   static int _remainingLessonCount({

--- a/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart
+++ b/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart
@@ -15,6 +15,11 @@ typedef TimetableAccentResolver = Color Function(CalendarEntry entry);
 abstract final class TimetableLiveActivityResolver {
   TimetableLiveActivityResolver._();
 
+  /// Wie im Wochen-Stundenplan: unbekannte Metadaten ausblenden, wenn
+  /// Profil-Filter aktiv sind.
+  static bool _hideUnknownWhenFilterActive(CalendarFiltersState filters) =>
+      filters.hasInitializedDefaults && filters.hasActiveFilters;
+
   static TimetableLiveActivitySnapshot? resolve({
     required DateTime day,
     required List<CalendarEntry> entries,
@@ -32,7 +37,7 @@ abstract final class TimetableLiveActivityResolver {
     final filtered = applyCalendarDisplayFilters(
       entries: entries,
       filters: filters,
-      hideUnknownWhenFilterActive: false,
+      hideUnknownWhenFilterActive: _hideUnknownWhenFilterActive(filters),
       forEventList: true,
     ).where((entry) {
       if (entry.type != CalendarEntryType.lesson &&
@@ -141,7 +146,7 @@ abstract final class TimetableLiveActivityResolver {
     final filtered = applyCalendarDisplayFilters(
       entries: entries,
       filters: filters,
-      hideUnknownWhenFilterActive: false,
+      hideUnknownWhenFilterActive: _hideUnknownWhenFilterActive(filters),
       forEventList: true,
     ).where((e) => e.type == CalendarEntryType.lesson).toList()
       ..sort((a, b) => a.startTime.compareTo(b.startTime));
@@ -161,7 +166,7 @@ abstract final class TimetableLiveActivityResolver {
     final filtered = applyCalendarDisplayFilters(
       entries: entries,
       filters: filters,
-      hideUnknownWhenFilterActive: false,
+      hideUnknownWhenFilterActive: _hideUnknownWhenFilterActive(filters),
       forEventList: true,
     ).where((entry) {
       return entry.type == CalendarEntryType.lesson ||

--- a/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_segment.dart
+++ b/lib/features/calendar/timetable_live_activity/domain/timetable_live_activity_segment.dart
@@ -10,6 +10,7 @@ class TimetableLiveActivitySegment {
     required this.id,
     required this.type,
     required this.title,
+    required this.shortTitle,
     required this.subtitle,
     required this.startMs,
     required this.endMs,
@@ -20,6 +21,7 @@ class TimetableLiveActivitySegment {
   final String id;
   final CalendarEntryType type;
   final String title;
+  final String shortTitle;
   final String subtitle;
   final int startMs;
   final int endMs;
@@ -34,6 +36,7 @@ class TimetableLiveActivitySegment {
       'id': id,
       'type': type.name,
       'title': title,
+      'shortTitle': shortTitle,
       'subtitle': subtitle,
       'startMs': startMs,
       'endMs': endMs,
@@ -66,6 +69,8 @@ class TimetableLiveActivitySegment {
       id: id,
       type: type,
       title: title,
+      shortTitle: json['shortTitle']?.toString() ??
+          _fallbackShortTitle(title),
       subtitle: json['subtitle']?.toString() ?? '',
       startMs: startMs,
       endMs: endMs,
@@ -96,4 +101,11 @@ class TimetableLiveActivitySegment {
   }
 
   static String accentHexFor(Color color) => SubjectColorCodec.toHex(color);
+
+  static String _fallbackShortTitle(String title) {
+    final trimmed = title.trim();
+    if (trimmed.isEmpty) return '';
+    if (trimmed.length <= 3) return trimmed;
+    return trimmed.substring(0, 3);
+  }
 }

--- a/test/features/calendar/timetable_live_activity/timetable_live_activity_logic_test.dart
+++ b/test/features/calendar/timetable_live_activity/timetable_live_activity_logic_test.dart
@@ -15,6 +15,8 @@ void main() {
       required DateTime start,
       required Duration duration,
       String name = 'Mathe',
+      String? location,
+      String? className,
       Color color = const Color(0xFF124E30),
     }) {
       return CalendarEntry(
@@ -25,6 +27,8 @@ void main() {
         accentColor: color,
         type: CalendarEntryType.lesson,
         subjectId: 'sub-1',
+        location: location,
+        className: className,
         choir: BackendChoir.unknown,
         voice: BackendVoice.unknown,
         schoolTrack: BackendSchoolTrack.unknown,
@@ -141,6 +145,44 @@ void main() {
       );
 
       expect(snapshot, isNull);
+    });
+
+    test('nutzt Raum als Untertitel und Fachkürzel im Segment', () {
+      final day = DateTime(2026, 7, 2);
+      final entries = [
+        lesson(
+          id: 'l1',
+          name: 'Mathematik',
+          location: 'A102',
+          className: '10a',
+          start: DateTime(2026, 7, 2, 8, 0),
+          duration: const Duration(hours: 1),
+        ),
+        lesson(
+          id: 'l2',
+          name: 'Englisch',
+          location: 'B204',
+          className: '10a',
+          start: DateTime(2026, 7, 2, 9, 0),
+          duration: const Duration(hours: 1),
+        ),
+      ];
+
+      final snapshot = TimetableLiveActivityResolver.resolve(
+        day: day,
+        entries: entries,
+        filters: filters,
+        resolveAccent: (e) => e.accentColor,
+        now: DateTime(2026, 7, 2, 8, 15),
+      );
+
+      expect(snapshot, isNotNull);
+      expect(snapshot!.currentSubtitle, 'A102');
+      expect(snapshot.nextSubtitle, 'B204');
+
+      final segments = snapshot.segments;
+      expect(segments.first.shortTitle, 'Mat');
+      expect(segments[1].shortTitle, 'Eng');
     });
   });
 }

--- a/test/features/calendar/timetable_live_activity/timetable_live_activity_logic_test.dart
+++ b/test/features/calendar/timetable_live_activity/timetable_live_activity_logic_test.dart
@@ -1,4 +1,5 @@
 import 'package:chronoapp/core/database/backend_enums.dart';
+import 'package:chronoapp/features/calendar/domain/filter/calendar_filter_defaults.dart';
 import 'package:chronoapp/features/calendar/domain/filter/calendar_filters_state.dart';
 import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
 import 'package:chronoapp/features/calendar/timetable_live_activity/domain/timetable_live_activity_resolver.dart';
@@ -183,6 +184,55 @@ void main() {
       final segments = snapshot.segments;
       expect(segments.first.shortTitle, 'Mat');
       expect(segments[1].shortTitle, 'Eng');
+    });
+
+    test('zählt nur gefilterte Stunden in Noch X Stunden', () {
+      final day = DateTime(2026, 7, 2);
+      final filters = calendarFiltersStateFromProfileFields(className: '10a');
+      final entries = [
+        lesson(
+          id: 'l1',
+          name: 'Physik',
+          className: '10a',
+          start: DateTime(2026, 7, 2, 8, 0),
+          duration: const Duration(hours: 1),
+        ),
+        lesson(
+          id: 'l2',
+          name: 'Chemie',
+          className: '10b',
+          start: DateTime(2026, 7, 2, 9, 0),
+          duration: const Duration(hours: 1),
+        ),
+        lesson(
+          id: 'l3',
+          name: 'Englisch',
+          className: '10a',
+          start: DateTime(2026, 7, 2, 10, 0),
+          duration: const Duration(hours: 1),
+        ),
+        lesson(
+          id: 'l4',
+          name: 'Bio',
+          className: '10b',
+          start: DateTime(2026, 7, 2, 11, 0),
+          duration: const Duration(hours: 1),
+        ),
+      ];
+
+      final snapshot = TimetableLiveActivityResolver.resolve(
+        day: day,
+        entries: entries,
+        filters: filters,
+        resolveAccent: (e) => e.accentColor,
+        now: DateTime(2026, 7, 2, 8, 15),
+      );
+
+      expect(snapshot, isNotNull);
+      expect(snapshot!.segments.where((s) => s.isLesson).length, 2);
+      expect(snapshot.remainingLessons, 2);
+      expect(snapshot.currentTitle, 'Physik');
+      expect(snapshot.nextTitle, 'Englisch');
     });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## UI-Fixes für Stundenplan-Live-Activity

Behebt die gemeldeten Darstellungsprobleme auf Lockscreen und Dynamic Island.

### Änderungen

- **Lockscreen-Padding:** Eigenes `timetableLockScreen`-Layout mit ausgewogenem Top-Padding (28pt)
- **Countdown:** Nutzt natives `Text(timerInterval: segmentStart...segmentEnd)` statt verschachtelter `TimelineView`
- **Dynamic Island:** Kompakteres Zwei-Zeilen-Layout; Fachkürzel in Compact-Ansicht
- **Untertitel:** Raum statt Klassenname; **Noch X Stunden** nur für gefilterte Stunden
- **Event-Live-Activity (Ablaufplan):** Schwarzer Lockscreen-Hintergrund mit Liquid-Glass-Rand (iOS 26+); Stundenplan unverändert
- **Android:** Raum, `shortTitle`, Compact-Label

### Hinweis

Widget-Extension-Änderungen erfordern einen **neuen iOS-Build**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20a8d8e7-9905-41ae-9e48-83918f68fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20a8d8e7-9905-41ae-9e48-83918f68fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

