### PR TITLE
Kalender: Schulzweige konsistent anzeigen und gleichzeitige Stunden nebeneinander

### DIFF
--- a/lib/features/calendar/domain/layout/school_track_lane_order.dart
+++ b/lib/features/calendar/domain/layout/school_track_lane_order.dart
@@ -1,0 +1,66 @@
+import 'package:chronoapp/core/database/backend_enums.dart';
+import 'package:chronoapp/features/calendar/domain/filter/calendar_filter_text.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+
+/// Stabile Lane-Reihenfolge für Schulstunden bei mehreren aktiven Schulzweigen.
+///
+/// Eigener Profil-Zweig steht links, danach feste Reihenfolge NTG → Musisch → unbekannt.
+int schoolTrackLanePriority(
+  CalendarEntry entry, {
+  required List<String> ownSchoolTracks,
+}) {
+  if (entry.type != CalendarEntryType.lesson) {
+    return 100;
+  }
+
+  final normalizedTrack = normalizeCalendarFilterText(
+    entry.schoolTrack.toBackend(),
+  );
+  if (normalizedTrack != null && ownSchoolTracks.contains(normalizedTrack)) {
+    return 0;
+  }
+
+  return switch (entry.schoolTrack) {
+    BackendSchoolTrack.ntg => 1,
+    BackendSchoolTrack.musisch => 2,
+    BackendSchoolTrack.unknown => 3,
+  };
+}
+
+int compareCalendarEntriesForLaneOrder(
+  CalendarEntry a,
+  CalendarEntry b, {
+  required List<String> ownSchoolTracks,
+}) {
+  final byStart = a.startTime.compareTo(b.startTime);
+  if (byStart != 0) return byStart;
+
+  final byEnd = b.endTime.compareTo(a.endTime);
+  if (byEnd != 0) return byEnd;
+
+  final byTrack = schoolTrackLanePriority(
+    a,
+    ownSchoolTracks: ownSchoolTracks,
+  ).compareTo(
+    schoolTrackLanePriority(b, ownSchoolTracks: ownSchoolTracks),
+  );
+  if (byTrack != 0) return byTrack;
+
+  return a.id.compareTo(b.id);
+}
+
+bool isOtherSchoolTrackLesson(
+  CalendarEntry entry, {
+  required List<String> ownSchoolTracks,
+}) {
+  if (entry.type != CalendarEntryType.lesson || ownSchoolTracks.isEmpty) {
+    return false;
+  }
+  if (entry.schoolTrack == BackendSchoolTrack.unknown) {
+    return false;
+  }
+  final normalizedTrack = normalizeCalendarFilterText(
+    entry.schoolTrack.toBackend(),
+  );
+  return normalizedTrack == null || !ownSchoolTracks.contains(normalizedTrack);
+}

--- a/lib/features/calendar/presentation/providers/calendar_accent_overrides_provider.dart
+++ b/lib/features/calendar/presentation/providers/calendar_accent_overrides_provider.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../domain/filter/calendar_filter_text.dart';
+import '../../domain/layout/school_track_lane_order.dart';
 import '../../domain/models/calendar_entry.dart';
 import 'filter/calendar/calendar_filters_provider.dart';
 import '../widgets/calendar_header/calendar_marker_color_palette.dart';
@@ -99,16 +100,37 @@ Color resolveCalendarEntryAccent(WidgetRef ref, CalendarEntry entry) {
     }
   }
 
-  if (type == CalendarEntryType.lesson && entry.subjectId != null) {
-    final subjectOverrides = ref.watch(subjectAccentOverridesProvider).value ??
-        const <String, Color>{};
-    final subjectOverride = subjectOverrides[entry.subjectId!];
-    if (subjectOverride != null) return subjectOverride;
-    return entry.accentColor;
+  if (type == CalendarEntryType.lesson) {
+    final ownSchoolTracks = ref.watch(
+      calendarFiltersProvider.select((filters) => filters.defaultSchoolTracks),
+    );
+    Color accent;
+    if (entry.subjectId != null) {
+      final subjectOverrides = ref.watch(subjectAccentOverridesProvider).value ??
+          const <String, Color>{};
+      accent = subjectOverrides[entry.subjectId!] ?? entry.accentColor;
+    } else {
+      accent = entry.accentColor;
+    }
+    if (isOtherSchoolTrackLesson(entry, ownSchoolTracks: ownSchoolTracks)) {
+      return _mutedLessonAccent(accent);
+    }
+    return accent;
   }
 
   final overrides = ref.watch(calendarAccentOverridesProvider);
   return overrides[entry.type] ?? entry.accentColor;
+}
+
+bool isOtherSchoolTrackLessonForRef(WidgetRef ref, CalendarEntry entry) {
+  final ownSchoolTracks = ref.watch(
+    calendarFiltersProvider.select((filters) => filters.defaultSchoolTracks),
+  );
+  return isOtherSchoolTrackLesson(entry, ownSchoolTracks: ownSchoolTracks);
+}
+
+Color _mutedLessonAccent(Color accent) {
+  return Color.lerp(accent, const Color(0xFF9E9E9E), 0.45) ?? accent;
 }
 
 /// Farbe des linken Streifens in Terminkarten — bei Chor-Beige besser lesbar.

--- a/lib/features/calendar/presentation/widgets/event_list/cards/lession_card.dart
+++ b/lib/features/calendar/presentation/widgets/event_list/cards/lession_card.dart
@@ -44,6 +44,7 @@ class LessionCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final accent = resolveCalendarEntryAccent(ref, entry);
+    final isOtherSchoolTrack = isOtherSchoolTrackLessonForRef(ref, entry);
     final lookupKey = lessonHomeworkLookupKeyForEntry(entry);
     final openTasks = lookupKey == null
         ? const <HomeworkTask>[]
@@ -64,9 +65,10 @@ class LessionCard extends ConsumerWidget {
           contentPadding:
               contentPadding ?? CalendarCardLeadingIndicator.contentPadding,
           titleFontSize: titleFontSize,
-          backgroundColor: CalendarPresentationTheme.lessonCardBackgroundColor(
+          backgroundColor: _lessonBackgroundColor(
             context,
             accent,
+            isOtherSchoolTrack: isOtherSchoolTrack,
           ),
           leadingIndicatorColor: accent,
           modalHeaderPreview: modalHeaderPreview,
@@ -83,5 +85,18 @@ class LessionCard extends ConsumerWidget {
           ),
       ],
     );
+  }
+
+  Color _lessonBackgroundColor(
+    BuildContext context,
+    Color accent, {
+    required bool isOtherSchoolTrack,
+  }) {
+    final base = CalendarPresentationTheme.lessonCardBackgroundColor(
+      context,
+      accent,
+    );
+    if (!isOtherSchoolTrack) return base;
+    return CalendarPresentationTheme.dimmedSurface(context, base);
   }
 }

--- a/lib/features/calendar/presentation/widgets/event_list/day_page.dart
+++ b/lib/features/calendar/presentation/widgets/event_list/day_page.dart
@@ -10,6 +10,7 @@ import '../../../domain/models/calendar_entry.dart';
 import '../../providers/calendar_providers.dart';
 import 'calendar_break_tile.dart';
 import 'calendar_day_empty_state.dart';
+import 'day_schedule_layout.dart';
 import 'package:chronoapp/features/calendar/presentation/widgets/event_list/calendar_now_anchor.dart';
 import 'cards/calendar_entry_card.dart';
 
@@ -46,8 +47,54 @@ class _DayPageState extends ConsumerState<DayPage> {
     super.dispose();
   }
 
-  int _entryIndexForNowAnchor(List<CalendarEntry> entries) {
-    return CalendarNowAnchor.entryIndexForNowAnchor(entries);
+  int _entryIndexForNowAnchor(List<DayScheduleListItem> items) {
+    return entryIndexForNowAnchorInDayItems(items);
+  }
+
+  Widget _buildLessonRow({
+    required DayScheduleLessonRowItem item,
+    required bool shouldApplyPastStyling,
+  }) {
+    final lessons = item.lessons;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.l),
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (var i = 0; i < lessons.length; i++) ...[
+              if (i > 0) const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: CalendarEntryCard(
+                  key: ValueKey<String>('calendar-entry-${lessons[i].id}'),
+                  entry: lessons[i],
+                  applyPastStyling: shouldApplyPastStyling,
+                  showTimeColumn: i == 0,
+                  listTileHorizontalPadding: 0,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildListItem({
+    required DayScheduleListItem item,
+    required bool shouldApplyPastStyling,
+  }) {
+    return switch (item) {
+      DayScheduleSingleItem(:final entry) => CalendarEntryCard(
+        key: ValueKey<String>('calendar-entry-${entry.id}'),
+        entry: entry,
+        applyPastStyling: shouldApplyPastStyling,
+      ),
+      DayScheduleLessonRowItem() => _buildLessonRow(
+        item: item,
+        shouldApplyPastStyling: shouldApplyPastStyling,
+      ),
+    };
   }
 
   String _buildCombinedBreakLabel(List<CalendarEntry> breakEntries) {
@@ -149,6 +196,9 @@ class _DayPageState extends ConsumerState<DayPage> {
     final entriesAsync = ref.watch(
       filteredCalendarEntriesForDayProvider(widget.date),
     );
+    final ownSchoolTracks = ref.watch(
+      calendarFiltersProvider.select((filters) => filters.defaultSchoolTracks),
+    );
     final shouldApplyPastStyling = AppDateTime.isTodayLocal(widget.date);
 
     return entriesAsync.when(
@@ -159,6 +209,10 @@ class _DayPageState extends ConsumerState<DayPage> {
         final regularEntries = entries
             .where((entry) => entry.type != CalendarEntryType.breakType)
             .toList(growable: false);
+        final listItems = buildDayScheduleListItems(
+          entries: regularEntries,
+          ownSchoolTracks: ownSchoolTracks,
+        );
         final hasBreakSummary = breakEntries.isNotEmpty;
 
         if (regularEntries.isEmpty && !hasBreakSummary) {
@@ -184,13 +238,13 @@ class _DayPageState extends ConsumerState<DayPage> {
         CalendarImagePrefetch.prefetchEntries(regularEntries);
 
         final isToday = AppDateTime.isTodayLocal(widget.date);
-        final nowAnchorEntryIndex = isToday
-            ? _entryIndexForNowAnchor(regularEntries)
+        final nowAnchorItemIndex = isToday
+            ? _entryIndexForNowAnchor(listItems)
             : -1;
-        final hasNowAnchor = isToday && regularEntries.isNotEmpty;
+        final hasNowAnchor = isToday && listItems.isNotEmpty;
         final listStartOffset = hasBreakSummary ? 1 : 0;
         final nowAnchorBuilderIndex = hasNowAnchor
-            ? listStartOffset + nowAnchorEntryIndex
+            ? listStartOffset + nowAnchorItemIndex
             : -1;
         if (hasNowAnchor) {
           _scheduleInitialScrollToNowAnchor();
@@ -204,12 +258,12 @@ class _DayPageState extends ConsumerState<DayPage> {
               bottom: AppSpacing.m + MediaQuery.paddingOf(context).bottom,
             ),
             itemCount:
-                regularEntries.length +
+                listItems.length +
                 (hasNowAnchor ? 1 : 0) +
                 (hasBreakSummary ? 1 : 0),
             itemBuilder: (context, index) {
               final lastIndex =
-                  regularEntries.length +
+                  listItems.length +
                   (hasNowAnchor ? 1 : 0) +
                   (hasBreakSummary ? 1 : 0) -
                   1;
@@ -218,21 +272,20 @@ class _DayPageState extends ConsumerState<DayPage> {
                 row = _buildBreakSummaryRow(breakEntries);
               } else if (hasNowAnchor &&
                   index == nowAnchorBuilderIndex &&
-                  regularEntries.isNotEmpty) {
+                  listItems.isNotEmpty) {
                 row = SizedBox(key: _nowAnchorKey, height: 1);
               } else {
                 final localIndex = hasBreakSummary ? index - 1 : index;
                 final isAfterNowAnchor =
                     hasNowAnchor &&
                     localIndex > nowAnchorBuilderIndex - listStartOffset;
-                final entryIndex = isAfterNowAnchor
+                final itemIndex = isAfterNowAnchor
                     ? localIndex - 1
                     : localIndex;
-                final entry = regularEntries[entryIndex];
-                row = CalendarEntryCard(
-                  key: ValueKey<String>('calendar-entry-${entry.id}'),
-                  entry: entry,
-                  applyPastStyling: shouldApplyPastStyling,
+                final item = listItems[itemIndex];
+                row = _buildListItem(
+                  item: item,
+                  shouldApplyPastStyling: shouldApplyPastStyling,
                 );
               }
               return Column(

--- a/lib/features/calendar/presentation/widgets/event_list/day_schedule_layout.dart
+++ b/lib/features/calendar/presentation/widgets/event_list/day_schedule_layout.dart
@@ -1,0 +1,151 @@
+import 'package:chronoapp/features/calendar/domain/layout/school_track_lane_order.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:chronoapp/features/calendar/presentation/widgets/event_list/calendar_now_anchor.dart';
+
+sealed class DayScheduleListItem {
+  const DayScheduleListItem();
+
+  DateTime get sortStartTime;
+
+  Iterable<CalendarEntry> get entries;
+}
+
+final class DayScheduleSingleItem extends DayScheduleListItem {
+  const DayScheduleSingleItem(this.entry);
+
+  final CalendarEntry entry;
+
+  @override
+  DateTime get sortStartTime => entry.startTime;
+
+  @override
+  Iterable<CalendarEntry> get entries => [entry];
+}
+
+final class DayScheduleLessonRowItem extends DayScheduleListItem {
+  const DayScheduleLessonRowItem(this.lessons);
+
+  final List<CalendarEntry> lessons;
+
+  @override
+  DateTime get sortStartTime => lessons.first.startTime;
+
+  @override
+  Iterable<CalendarEntry> get entries => lessons;
+}
+
+List<DayScheduleListItem> buildDayScheduleListItems({
+  required List<CalendarEntry> entries,
+  required List<String> ownSchoolTracks,
+}) {
+  if (entries.isEmpty) return const [];
+
+  final lessonGroups = _groupOverlappingLessons(
+    entries,
+    ownSchoolTracks: ownSchoolTracks,
+  );
+  final groupedLessonIds = <String>{
+    for (final group in lessonGroups) for (final lesson in group) lesson.id,
+  };
+
+  final items = <DayScheduleListItem>[
+    for (final entry in entries)
+      if (!groupedLessonIds.contains(entry.id))
+        DayScheduleSingleItem(entry),
+    for (final group in lessonGroups) DayScheduleLessonRowItem(group),
+  ]..sort((a, b) {
+    final byStart = a.sortStartTime.compareTo(b.sortStartTime);
+    if (byStart != 0) return byStart;
+    return _stableItemOrder(a).compareTo(_stableItemOrder(b));
+  });
+
+  return items;
+}
+
+int entryIndexForNowAnchorInDayItems(List<DayScheduleListItem> items) {
+  final flatEntries = <CalendarEntry>[
+    for (final item in items) ...item.entries,
+  ];
+  final anchorEntryIndex = CalendarNowAnchor.entryIndexForNowAnchor(
+    flatEntries,
+  );
+  if (anchorEntryIndex >= flatEntries.length) {
+    return items.length;
+  }
+
+  final anchorEntry = flatEntries[anchorEntryIndex];
+  for (var i = 0; i < items.length; i++) {
+    if (items[i].entries.any((entry) => entry.id == anchorEntry.id)) {
+      return i;
+    }
+  }
+  return items.length;
+}
+
+int _stableItemOrder(DayScheduleListItem item) {
+  return switch (item) {
+    DayScheduleSingleItem(:final entry) => entry.type.index,
+    DayScheduleLessonRowItem() => CalendarEntryType.lesson.index,
+  };
+}
+
+List<List<CalendarEntry>> _groupOverlappingLessons(
+  List<CalendarEntry> entries, {
+  required List<String> ownSchoolTracks,
+}) {
+  final lessons = entries
+      .where((entry) => entry.type == CalendarEntryType.lesson)
+      .toList(growable: false);
+  if (lessons.length < 2) return const [];
+
+  final sortedLessons = [...lessons]
+    ..sort(
+      (a, b) => compareCalendarEntriesForLaneOrder(
+        a,
+        b,
+        ownSchoolTracks: ownSchoolTracks,
+      ),
+    );
+
+  final groups = <List<CalendarEntry>>[];
+  var currentGroup = <CalendarEntry>[sortedLessons.first];
+  var groupEnd = sortedLessons.first.endTime;
+
+  for (var i = 1; i < sortedLessons.length; i++) {
+    final lesson = sortedLessons[i];
+    if (lesson.startTime.isBefore(groupEnd)) {
+      currentGroup.add(lesson);
+      if (lesson.endTime.isAfter(groupEnd)) {
+        groupEnd = lesson.endTime;
+      }
+      continue;
+    }
+
+    if (currentGroup.length > 1) {
+      groups.add(_sortedLessonGroup(currentGroup, ownSchoolTracks));
+    }
+    currentGroup = [lesson];
+    groupEnd = lesson.endTime;
+  }
+
+  if (currentGroup.length > 1) {
+    groups.add(_sortedLessonGroup(currentGroup, ownSchoolTracks));
+  }
+
+  return groups;
+}
+
+List<CalendarEntry> _sortedLessonGroup(
+  List<CalendarEntry> lessons,
+  List<String> ownSchoolTracks,
+) {
+  final sorted = [...lessons]
+    ..sort(
+      (a, b) => compareCalendarEntriesForLaneOrder(
+        a,
+        b,
+        ownSchoolTracks: ownSchoolTracks,
+      ),
+    );
+  return sorted;
+}

--- a/lib/features/calendar/presentation/widgets/event_list/week_schedule_day_columns.dart
+++ b/lib/features/calendar/presentation/widgets/event_list/week_schedule_day_columns.dart
@@ -12,8 +12,10 @@ import 'package:chronoapp/features/calendar/presentation/widgets/event_list/week
 import 'package:chronoapp/features/calendar/presentation/widgets/event_list/week_schedule_timeline.dart';
 import 'package:chronoapp/features/calendar/presentation/widgets/event_list/week_schedule_viewport.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/widgets/app_hairline_divider.dart';
+import '../../providers/filter/calendar/calendar_filters_provider.dart';
 
 /// Eine Tages-Spalte im Wochenraster (Tablet: in [WeekDayColumns], Handy:
 /// in [WeekScheduleMobileBody] mit fester Breite / nahtlosem Streifen).
@@ -152,7 +154,7 @@ class WeekDayColumns extends StatelessWidget {
   }
 }
 
-class WeekEntriesLayer extends StatelessWidget {
+class WeekEntriesLayer extends ConsumerWidget {
   const WeekEntriesLayer({
     required this.entries,
     required this.day,
@@ -167,7 +169,10 @@ class WeekEntriesLayer extends StatelessWidget {
   final double hourHeight;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ownSchoolTracks = ref.watch(
+      calendarFiltersProvider.select((filters) => filters.defaultSchoolTracks),
+    );
     return LayoutBuilder(
       builder: (context, constraints) {
         final regularEntries = entries
@@ -179,6 +184,7 @@ class WeekEntriesLayer extends StatelessWidget {
           day: day,
           bounds: bounds,
           hourHeight: hourHeight,
+          ownSchoolTracks: ownSchoolTracks,
           adjacentEntryGap: compactMobile
               ? kWeekScheduleAdjacentEntryGapPhone
               : kWeekScheduleAdjacentEntryGap,

--- a/lib/features/calendar/presentation/widgets/event_list/week_schedule_layout.dart
+++ b/lib/features/calendar/presentation/widgets/event_list/week_schedule_layout.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:chronoapp/core/time/app_date_time.dart';
+import 'package:chronoapp/features/calendar/domain/layout/school_track_lane_order.dart';
 import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
 
 const double kWeekScheduleHourHeight = 72;
@@ -99,8 +100,13 @@ List<WeekEntryPlacement> buildWeekEntryPlacements({
   required WeekScheduleBounds bounds,
   required double hourHeight,
   double adjacentEntryGap = kWeekScheduleAdjacentEntryGap,
+  List<String> ownSchoolTracks = const [],
 }) {
-  final intervals = _buildIntervals(entries: entries, day: day);
+  final intervals = _buildIntervals(
+    entries: entries,
+    day: day,
+    ownSchoolTracks: ownSchoolTracks,
+  );
   final placements = <WeekEntryPlacement>[];
   var index = 0;
 
@@ -166,6 +172,7 @@ List<WeekEntryPlacement> buildWeekEntryPlacements({
 List<_EntryInterval> _buildIntervals({
   required List<CalendarEntry> entries,
   required DateTime day,
+  List<String> ownSchoolTracks = const [],
 }) {
   final intervals = <_EntryInterval>[];
 
@@ -186,7 +193,13 @@ List<_EntryInterval> _buildIntervals({
   intervals.sort((a, b) {
     final byStart = a.start.compareTo(b.start);
     if (byStart != 0) return byStart;
-    return b.end.compareTo(a.end);
+    final byEnd = b.end.compareTo(a.end);
+    if (byEnd != 0) return byEnd;
+    return compareCalendarEntriesForLaneOrder(
+      a.entry,
+      b.entry,
+      ownSchoolTracks: ownSchoolTracks,
+    );
   });
   return intervals;
 }

--- a/test/features/calendar/school_track_lane_order_test.dart
+++ b/test/features/calendar/school_track_lane_order_test.dart
@@ -1,0 +1,125 @@
+import 'package:chronoapp/core/database/backend_enums.dart';
+import 'package:chronoapp/features/calendar/domain/layout/school_track_lane_order.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:chronoapp/features/calendar/presentation/widgets/event_list/day_schedule_layout.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+CalendarEntry _lesson({
+  required String id,
+  required DateTime start,
+  required DateTime end,
+  BackendSchoolTrack schoolTrack = BackendSchoolTrack.ntg,
+}) {
+  return CalendarEntry(
+    id: id,
+    eventName: id,
+    startTime: start,
+    endTime: end,
+    accentColor: Colors.blue,
+    type: CalendarEntryType.lesson,
+    schoolTrack: schoolTrack,
+  );
+}
+
+void main() {
+  group('schoolTrackLanePriority', () {
+    test('eigener Schulzweig steht vor fremden Zweigen', () {
+      final own = _lesson(
+        id: 'own',
+        start: DateTime(2024, 6, 15, 8),
+        end: DateTime(2024, 6, 15, 9),
+        schoolTrack: BackendSchoolTrack.musisch,
+      );
+      final other = _lesson(
+        id: 'other',
+        start: DateTime(2024, 6, 15, 8),
+        end: DateTime(2024, 6, 15, 9),
+        schoolTrack: BackendSchoolTrack.ntg,
+      );
+
+      expect(
+        schoolTrackLanePriority(own, ownSchoolTracks: ['musisch']),
+        lessThan(schoolTrackLanePriority(other, ownSchoolTracks: ['musisch'])),
+      );
+    });
+
+    test('fremde Schulzweige folgen fester Reihenfolge NTG vor Musisch', () {
+      final ntg = _lesson(
+        id: 'ntg',
+        start: DateTime(2024, 6, 15, 8),
+        end: DateTime(2024, 6, 15, 9),
+        schoolTrack: BackendSchoolTrack.ntg,
+      );
+      final musisch = _lesson(
+        id: 'musisch',
+        start: DateTime(2024, 6, 15, 8),
+        end: DateTime(2024, 6, 15, 9),
+        schoolTrack: BackendSchoolTrack.musisch,
+      );
+
+      expect(
+        schoolTrackLanePriority(ntg, ownSchoolTracks: const []),
+        lessThan(schoolTrackLanePriority(musisch, ownSchoolTracks: const [])),
+      );
+    });
+  });
+
+  group('buildDayScheduleListItems', () {
+    test('gruppiert überlappende Schulstunden in einer Zeile', () {
+      final start = DateTime(2024, 6, 15, 8);
+      final end = DateTime(2024, 6, 15, 9);
+      final own = _lesson(
+        id: 'own',
+        start: start,
+        end: end,
+        schoolTrack: BackendSchoolTrack.ntg,
+      );
+      final other = _lesson(
+        id: 'other',
+        start: start,
+        end: end,
+        schoolTrack: BackendSchoolTrack.musisch,
+      );
+      final meal = CalendarEntry(
+        id: 'meal',
+        eventName: 'Mensa',
+        startTime: DateTime(2024, 6, 15, 12),
+        endTime: DateTime(2024, 6, 15, 13),
+        accentColor: Colors.green,
+        type: CalendarEntryType.meal,
+      );
+
+      final items = buildDayScheduleListItems(
+        entries: [other, meal, own],
+        ownSchoolTracks: ['ntg'],
+      );
+
+      expect(items, hasLength(2));
+      expect(items.first, isA<DayScheduleLessonRowItem>());
+      final row = items.first as DayScheduleLessonRowItem;
+      expect(row.lessons.map((lesson) => lesson.id), ['own', 'other']);
+      expect(items.last, isA<DayScheduleSingleItem>());
+    });
+
+    test('lässt nicht überlappende Schulstunden getrennt', () {
+      final items = buildDayScheduleListItems(
+        entries: [
+          _lesson(
+            id: 'a',
+            start: DateTime(2024, 6, 15, 8),
+            end: DateTime(2024, 6, 15, 9),
+          ),
+          _lesson(
+            id: 'b',
+            start: DateTime(2024, 6, 15, 10),
+            end: DateTime(2024, 6, 15, 11),
+          ),
+        ],
+        ownSchoolTracks: const ['ntg'],
+      );
+
+      expect(items.every((item) => item is DayScheduleSingleItem), isTrue);
+    });
+  });
+}

--- a/test/features/calendar/week_schedule_layout_test.dart
+++ b/test/features/calendar/week_schedule_layout_test.dart
@@ -1,0 +1,54 @@
+import 'package:chronoapp/core/database/backend_enums.dart';
+import 'package:chronoapp/features/calendar/domain/models/calendar_entry.dart';
+import 'package:chronoapp/features/calendar/presentation/widgets/event_list/week_schedule_layout.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+CalendarEntry _lesson({
+  required String id,
+  required DateTime start,
+  required DateTime end,
+  BackendSchoolTrack schoolTrack = BackendSchoolTrack.ntg,
+}) {
+  return CalendarEntry(
+    id: id,
+    eventName: id,
+    startTime: start,
+    endTime: end,
+    accentColor: Colors.blue,
+    type: CalendarEntryType.lesson,
+    schoolTrack: schoolTrack,
+  );
+}
+
+void main() {
+  test('buildWeekEntryPlacements ordnet eigenen Schulzweig links', () {
+    final day = DateTime(2024, 6, 15);
+    final start = DateTime(2024, 6, 15, 8);
+    final end = DateTime(2024, 6, 15, 9);
+    final own = _lesson(
+      id: 'own',
+      start: start,
+      end: end,
+      schoolTrack: BackendSchoolTrack.musisch,
+    );
+    final other = _lesson(
+      id: 'other',
+      start: start,
+      end: end,
+      schoolTrack: BackendSchoolTrack.ntg,
+    );
+
+    final placements = buildWeekEntryPlacements(
+      entries: [other, own],
+      day: day,
+      bounds: const WeekScheduleBounds(startMinute: 8 * 60, endMinute: 18 * 60),
+      hourHeight: 72,
+      ownSchoolTracks: ['musisch'],
+    );
+
+    expect(placements, hasLength(2));
+    expect(placements.firstWhere((p) => p.entry.id == 'own').lane, 0);
+    expect(placements.firstWhere((p) => p.entry.id == 'other').lane, 1);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Verbessert die Darstellung bei mehreren ausgewählten Schulzweigen in Tages- und Wochenansicht:

- **Konsistente Reihenfolge:** Der eigene Profil-Schulzweig erscheint immer links, fremde Zweige folgen in fester Reihenfolge (NTG → Musisch). Behebt die bisher scheinbar zufällige Links/Rechts-Anordnung.
- **Visuelle Unterscheidung:** Schulstunden eines fremden Zweigs werden abgeschwächt dargestellt (gedimmter Hintergrund + entsättigte Akzentfarbe).
- **Tagesansicht:** Gleichzeitige Schulstunden werden nebeneinander in einer Zeile angezeigt statt untereinander gestapelt. Andere Termintypen bleiben unverändert in voller Breite.

## Änderungen

- Neuer Domain-Helper `school_track_lane_order.dart` für stabile Lane-Priorität
- Wochenansicht: `buildWeekEntryPlacements` nutzt Schulzweig-Sortierung als Tiebreaker
- Tagesansicht: neues `day_schedule_layout.dart` gruppiert überlappende Schulstunden
- `LessionCard` / `resolveCalendarEntryAccent`: abgeschwächtes Styling für fremde Schulzweige

## Tests

- `school_track_lane_order_test.dart` – Lane-Priorität und Tages-Gruppierung
- `week_schedule_layout_test.dart` – eigener Schulzweig links in der Wochenansicht

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2993fc0-9e3b-4326-bb5b-362d216659ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2993fc0-9e3b-4326-bb5b-362d216659ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

