### PR TITLE
README überarbeiten mit Screenshot-Platzhaltern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,206 @@
 <div align="center">
 
-# 🗓️ Chrono
+<img src="assets/domspatzen_compact.svg" alt="Chrono Logo" width="72" height="72" />
 
-**Dein persönlicher All-in-One-Kalender · Your Personal All-in-One Calendar**
+# Chrono
 
-[![Flutter](https://img.shields.io/badge/Flutter-3.x-02569B?style=for-the-badge&logo=flutter&logoColor=white)](https://flutter.dev)
-[![Dart](https://img.shields.io/badge/Dart-3.x-0175C2?style=for-the-badge&logo=dart&logoColor=white)](https://dart.dev)
+**Dein persönlicher All-in-One-Kalender für die Regensburger Domspatzen**
 
+Chorplan, Stundenplan, Speiseplan und Events — alles an einem Ort, auf dich zugeschnitten.
+
+<br />
+
+[![Flutter](https://img.shields.io/badge/Flutter-3.x-02569B?style=flat-square&logo=flutter&logoColor=white)](https://flutter.dev)
+[![Dart](https://img.shields.io/badge/Dart-3.x-0175C2?style=flat-square&logo=dart&logoColor=white)](https://dart.dev)
+[![Material 3](https://img.shields.io/badge/Material-3-6750A4?style=flat-square&logo=material-design&logoColor=white)](https://m3.material.io)
+[![Supabase](https://img.shields.io/badge/Supabase-Backend-3FCF8E?style=flat-square&logo=supabase&logoColor=white)](https://supabase.com)
+[![PowerSync](https://img.shields.io/badge/PowerSync-Offline--Sync-111827?style=flat-square)](https://www.powersync.com)
+
+<br />
+
+[Features](#features) · [Screenshots](#screenshots) · [Lokal starten](#lokal-starten) · [Architektur](#architektur) · [Tech-Stack](#tech-stack)
 
 </div>
 
 ---
 
-Wer bei den Regensburger Domspatzen ist, kennt das Problem: Chorplan hier, Stundenplan da, der Speiseplan irgendwo auf einem Aushang, Konzerttermine in einer anderen mail – und man verliert den Überblick.
+## Über Chrono
 
-Chrono soll das ändern.
+Wer bei den **Regensburger Domspatzen** ist, kennt das Problem: Chorplan hier, Stundenplan da, der Speiseplan irgendwo auf einem Aushang, Konzerttermine in einer anderen Mail — und man verliert den Überblick.
 
-Keine fünf verschiedenen nachrichten mehr. Kein ständiges Suchen. Alles an einem Ort, auf dich persönlich zugeschnitten.
-
----
-
-## Was Chrono können soll
-
-Wenn alles fertig ist, bündelt Chrono folgendes:
-
-- **Chorpläne** – Proben, Termine, was auch immer der Chor von dir braucht
-- **Stundenplan** – Schule direkt integriert, kein manuelles Eintragen
-- **Konzerte & Events** – Auftritte und besondere Termine auf einen Blick
-- **Speiseplan** – Was gibt's heute in der Mensa?
-- **Vertretungsplan** – Ausfälle und Änderungen, bevor du in den falschen Raum läufst
-
-Und das Wichtigste: Du siehst nur, was für *dich* relevant ist.
+**Chrono** bündelt alles in einer App. Keine fünf verschiedenen Nachrichten mehr, kein ständiges Suchen. Du siehst nur, was für *dich* relevant ist — gefiltert nach Chor, Stimme, Klasse, Schulzweig und Ernährung.
 
 ---
 
-## Stand der Dinge
+## Screenshots
 
-Das Flutter-Grundgerüst steht, die Struktur ist da – aber die eigentlichen Features kommen erst noch. Diese README beschreibt, wo die Reise hingeht, nicht wo sie gerade ist.
+> **Platzhalter:** Lege vier App-Store-Screenshots unter [`docs/screenshots/`](docs/screenshots/) ab.  
+> Anleitung: [`docs/screenshots/README.md`](docs/screenshots/README.md)
+
+<table>
+  <tr>
+    <td align="center" width="50%">
+      <img src="docs/screenshots/01-tagesansicht.png" alt="Tagesansicht — Platzhalter" width="280" /><br />
+      <sub><b>Tagesansicht</b> — Stundenplan & Termine</sub>
+    </td>
+    <td align="center" width="50%">
+      <img src="docs/screenshots/02-wochenansicht.png" alt="Wochenansicht — Platzhalter" width="280" /><br />
+      <sub><b>Wochenansicht</b> — Raster mit farbigen Karten</sub>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="50%">
+      <img src="docs/screenshots/03-filter-suche.png" alt="Filter & Suche — Platzhalter" width="280" /><br />
+      <sub><b>Filter & Suche</b> — Persönliche Ansicht</sub>
+    </td>
+    <td align="center" width="50%">
+      <img src="docs/screenshots/04-hausaufgaben.png" alt="Hausaufgaben — Platzhalter" width="280" /><br />
+      <sub><b>Hausaufgaben</b> — Aufgaben & Familie</sub>
+    </td>
+  </tr>
+</table>
 
 ---
 
-## Roadmap
+## Features
 
-Was noch kommt, in ungefähr dieser Reihenfolge:
+### Kalender
 
-- Chorplan-System
-- Stundenplan-Integration
-- Konzert- und Event-System
-- Speiseplan-Anbindung
-- Vertretungsplan
-- Benutzer-Accounts
-- Push-Benachrichtigungen
-- Dark Mode
-- Offline-Modus
-- Home-Screen-Widgets
+- **Tages- und Wochenansicht** mit farbcodierten Terminkarten
+- **Chorpläne**, **Schulstunden**, **Events** und **Speiseplan** in einer Oberfläche
+- **Intelligente Filter** nach Chor, Stimme, Klasse, Schulzweig (NTG / Musisch) und Ernährung
+- **Kalendersuche** mit eigenem Filter-Overlay
+- **Mehrere Schulzweige** gleichzeitig — eigener Zweig hervorgehoben, gleichzeitige Stunden nebeneinander
+- **Termindetails** mit Bildern, Ablaufplänen und Notizen
+- **Event-Editor** für Administratoren
+
+### Hausaufgaben
+
+- Aufgaben pro Fach anlegen und verwalten
+- Verknüpfung mit Schulstunden im Kalender
+- **Klassen-Vorschläge** von Mitschülern annehmen oder ablehnen
+
+### Konto & Familie
+
+- Anmeldung per **E-Mail**, **Google** oder **Apple**
+- Onboarding mit Profil (Chor, Stimme, Klasse, Schulzweig, Ernährung)
+- **Elternmodus**: Kinder verknüpfen und deren Kalender einsehen
+- Kindwechsel mit eigenen Kalenderfiltern pro Profil
+
+### Plattform-Integrationen
+
+- **Offline-Sync** über PowerSync — Kalender auch ohne Netz nutzbar
+- **Push-Benachrichtigungen** (Firebase Cloud Messaging)
+- **Live Activities** (iOS) für laufende Events und Stundenplan
+- **Home-Screen-Widget** mit Tagesvorschau
+- **Dark Mode** (System, Hell, Dunkel)
+
+### Weitere Details
+
+- Material-3-Design mit angepassten Akzentfarben pro Fach
+- Stimmgabel in den Einstellungen
+- Haptisches Feedback und flüssige Animationen
 
 ---
 
-## Lokal aufsetzen
+## Lokal starten
 
-Du brauchst Flutter (≥ 3.0) und Dart (≥ 3.0), der Rest ergibt sich:
+### Voraussetzungen
+
+- [Flutter](https://docs.flutter.dev/get-started/install) ≥ 3.0 (SDK `^3.11`)
+- Xcode (iOS) und/oder Android Studio
+- Optional: Firebase-Konfiguration für Push-Benachrichtigungen
+
+### Repository klonen
 
 ```bash
 git clone https://github.com/RiceJuice/chrono.git
 cd chrono
 flutter pub get
-flutter run
+```
+
+### Umgebungsvariablen (optional)
+
+Für eigene Supabase- oder Google-Auth-Keys kopiere die Beispiel-Datei und passe sie an:
+
+```bash
+cp config/dart_defines.example.json config/dart_defines.local.json
+```
+
+Start mit lokalen Defines:
+
+```bash
+flutter run --dart-define-from-file=config/dart_defines.local.json
+```
+
+Ohne eigene Datei nutzt die App die in `lib/main.dart` hinterlegten Standardwerte.
+
+### Tests
+
+```bash
+flutter test
+flutter analyze
 ```
 
 ---
 
-## Technisches
+## Architektur
 
-Gebaut mit Flutter. Läuft auf Android und iOS.
+Das Projekt folgt einer **Feature-basierten Clean Architecture**:
+
+```
+lib/
+├── core/           # Routing, Theme, DB/Sync, Auth, Push, Netzwerk
+└── features/
+    ├── calendar/   # Kalender, Filter, Suche, Live Activities, Widget
+    ├── homework/   # Hausaufgaben
+    ├── login/      # Auth, Onboarding, Eltern-Verknüpfung
+    └── settings/   # Profil, Darstellung, Familie
+```
+
+Jedes Feature ist in **`presentation/`**, **`domain/`** und **`data/`** gegliedert. State Management mit **Riverpod**, Navigation mit **go_router**.
 
 ---
+
+## Tech-Stack
+
+| Bereich | Technologie |
+|---|---|
+| Framework | Flutter · Dart |
+| UI | Material 3 · Google Fonts · Phosphor Icons |
+| State | Riverpod (+ Codegen) |
+| Navigation | go_router |
+| Backend & Auth | Supabase |
+| Lokale DB & Sync | PowerSync · SQLite |
+| Push | Firebase Cloud Messaging |
+| iOS Extras | Live Activities · Home Widget |
+
+---
+
+## Screenshots einfügen — Kurzanleitung
+
+1. Vier App-Store-Screenshots exportieren (PNG, idealerweise 1290 × 2796 px).
+2. In den Ordner [`docs/screenshots/`](docs/screenshots/) legen:
+   - `01-tagesansicht.png`
+   - `02-wochenansicht.png`
+   - `03-filter-suche.png`
+   - `04-hausaufgaben.png`
+3. Committen und pushen — die Bilder erscheinen automatisch in dieser README.
+
+Ausführliche Anleitung: [`docs/screenshots/README.md`](docs/screenshots/README.md)
+
+---
+
+## Status
+
+Chrono ist in aktiver Entwicklung. Kernfunktionen (Kalender, Sync, Auth, Hausaufgaben, Elternmodus) sind implementiert; weitere Verbesserungen und Features kommen laufend dazu.
+
+---
+
+<div align="center">
+
+**Gebaut für die Regensburger Domspatzen**
+
+<sub>Flutter · Supabase · PowerSync</sub>
+
+</div>

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,40 @@
+# App-Screenshots für die GitHub-README
+
+Lege hier **vier App-Store-Screenshots** ab, die in der [README.md](../../README.md) angezeigt werden.
+
+## Dateinamen (exakt so benennen)
+
+| Datei | Empfohlener Inhalt |
+|---|---|
+| `01-tagesansicht.png` | Tagesansicht mit Stundenplan, Chor oder Events |
+| `02-wochenansicht.png` | Wochenraster mit farbigen Terminkarten |
+| `03-filter-suche.png` | Kalenderfilter, Suche oder Termindetails |
+| `04-hausaufgaben.png` | Hausaufgaben, Einstellungen oder Elternmodus |
+
+## Format & Größe
+
+- **Format:** PNG oder JPG (PNG bevorzugt, schärfer bei UI-Screenshots)
+- **Seitenverhältnis:** 9:19,5 (iPhone) oder die Größe, die du im App Store nutzt — z. B. **1290 × 2796 px**
+- **Dateigröße:** unter ~1 MB pro Bild (GitHub rendert große Dateien langsamer)
+
+## Screenshots einfügen
+
+1. Screenshots vom iPhone/Mac exportieren oder in Xcode/App Store Connect herunterladen.
+2. Die vier Dateien in **diesen Ordner** (`docs/screenshots/`) legen — mit den Namen aus der Tabelle oben.
+3. In Git committen und pushen:
+
+   ```bash
+   git add docs/screenshots/
+   git commit -m "Screenshots für README hinzugefügt"
+   git push
+   ```
+
+4. Die README verweist bereits auf diese Pfade — nach dem Push erscheinen die Bilder automatisch auf GitHub.
+
+## Alternative Pfade
+
+Wenn du andere Dateinamen nutzen willst, passe die vier `![…](docs/screenshots/…)`-Zeilen in der [README.md](../../README.md) an.
+
+## Tipp: Platzhalter testen
+
+Solange noch keine echten Screenshots da sind, zeigt GitHub ein kaputtes Bild-Icon. Das ist normal — sobald die Dateien committed sind, werden sie ersetzt.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Überarbeitet die GitHub-README mit aktuellem Projektstand, klarer Struktur und Platzhaltern für vier App-Store-Screenshots.

## Änderungen

- Neuer Header mit Logo, Badges und Inhaltsverzeichnis
- Aktualisierte Feature-Liste (Kalender, Hausaufgaben, Elternmodus, Offline-Sync, Live Activities, Widget, Dark Mode)
- 2×2-Screenshot-Grid mit Platzhalter-Pfaden
- Setup-Anleitung inkl. `dart-define-from-file`
- Architektur- und Tech-Stack-Übersicht
- Neue Anleitung unter `docs/screenshots/README.md`

## Screenshots einfügen

Vier PNG-Dateien in `docs/screenshots/` ablegen — Details in `docs/screenshots/README.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2993fc0-9e3b-4326-bb5b-362d216659ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2993fc0-9e3b-4326-bb5b-362d216659ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

