### PR TITLE
Event Live Activities: bedarfsgesteuertes Scheduling statt Minuten-Cron

### DIFF
--- a/backend/PUSH_NOTIFICATIONS.md
+++ b/backend/PUSH_NOTIFICATIONS.md
@@ -180,11 +180,15 @@ supabase functions deploy notify-event-change
 
 ## 10. Ablaufplan Live Activities (`schedule-live-activity`)
 
-**Auslöser:**
-- pg_cron (jede Minute) → Segmentgrenzen (`start` / `end`)
-- **DB-Trigger** auf `calendar_events` (UPDATE/DELETE) und `event_schedules` (INSERT/UPDATE/DELETE) → sofortiger FCM `update` oder `end` bei laufender Live Activity
+**Auslöser (bedarfsgesteuert, kein Minuten-Polling):**
+- **Geplante Einmal-Jobs** (`event_live_activity_jobs` + pg_cron) → `start` / `end` exakt zu Termin- oder Segmentzeit — nur für `calendar_events` mit `type = 'event'`
+- **DB-Trigger** auf `calendar_events` (INSERT/UPDATE/DELETE) und `event_schedules` (INSERT/UPDATE/DELETE) → Job-Neuplanung + sofortiger FCM `update`/`end` bei laufender Live Activity
 
-**Lokal in der App:** `flutter_local_notifications` + Einmal-Timer planen Segmentstarts und Tagesende; Coordinator startet/beendet die Activity über `live_activities`. FCM `update` aktualisiert Inhalte (Titel, Zeiten, Zielgruppe).
+**Termine ohne Ablaufplan:** Eine Live Activity von `start_time` bis `end_time` (Titel = `event_name`).
+
+**Zielgruppe:** Nur Geräte, deren Profil zu `choir`/`voices` des Events passt.
+
+**Lokal in der App:** `flutter_local_notifications` + Einmal-Timer planen Segment-/Terminstarts und Tagesende; Coordinator startet/beendet die Activity über `live_activities`. FCM `update` aktualisiert Inhalte (Titel, Zeiten, Zielgruppe).
 
 ### Deploy
 
@@ -193,7 +197,7 @@ supabase db push
 supabase functions deploy schedule-live-activity --no-verify-jwt
 ```
 
-Migration `*_schedule_live_activity_change_trigger.sql` legt Postgres-Trigger an, die bei Termin-/Ablaufplan-Änderungen die Edge Function mit `{ "mode": "change", "event_id": "…" }` aufrufen (Vault-Secret muss gesetzt sein).
+Migration `*_event_live_activity_on_demand.sql` legt Job-Tabelle, Sync-Funktion und Postgres-Trigger an (Vault-Secret muss gesetzt sein).
 
 ### Secrets
 
@@ -216,7 +220,7 @@ SELECT vault.create_secret(
 Falls die Migration schon ohne Vault lief: komplettes Setup-Skript  
 [`backend/SCHEDULE_LIVE_ACTIVITY_CRON_SETUP.sql`](SCHEDULE_LIVE_ACTIVITY_CRON_SETUP.sql) im SQL Editor ausführen (Secret-Wert anpassen).
 
-Der pg_cron-Job liest das Secret aus `vault.decrypted_secrets`.
+Der pg_cron-Job für Minuten-Polling ist entfernt. Geplante Dispatches lesen das Secret aus `vault.decrypted_secrets`.
 
 ### Test (curl)
 
@@ -224,12 +228,12 @@ Der pg_cron-Job liest das Secret aus `vault.decrypted_secrets`.
 curl -X POST "https://chrbvfaknykaycwumuba.supabase.co/functions/v1/schedule-live-activity" \
   -H "Content-Type: application/json" \
   -H "x-cron-secret: <SCHEDULE_LIVE_ACTIVITY_CRON_SECRET>" \
-  -d '{}'
+  -d '{"mode":"dispatch","event_id":"<uuid>","action":"start"}'
 ```
 
-Erwartung: `{"processed":0,"sent":0,...}` oder Sends bei laufendem Ablaufplan.
+Erwartung: `{"processed":1,"sent":…,"mode":"dispatch",…}` oder `skipped` wenn kein passendes Event/Gerät.
 
-Ohne Secret: HTTP `401`.
+Ohne gültigen `mode`: HTTP `400`. Ohne Secret: HTTP `401`.
 
 ### iOS
 

--- a/backend/SCHEDULE_LIVE_ACTIVITY_CRON_SETUP.sql
+++ b/backend/SCHEDULE_LIVE_ACTIVITY_CRON_SETUP.sql
@@ -5,34 +5,22 @@
 SELECT vault.create_secret(
   'HIER-DEIN-SECRET-EINFÜGEN',
   'schedule_live_activity_cron_secret',
-  'Cron-Header für schedule-live-activity Edge Function'
+  'Interner Header für schedule-live-activity Edge Function'
 );
 
--- 2) Cron-Job neu planen (liest Secret aus Vault)
+-- 2) Minütlicher Polling-Cron ist entfernt — Dispatch wird bedarfsgesteuert
+--    über event_live_activity_jobs (Migration 20260704130000) geplant.
+--    Nach dem Secret-Setup bestehende Events nachplanen:
 DO $$
+DECLARE
+  r record;
 BEGIN
-  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'schedule-live-activity') THEN
-    PERFORM cron.unschedule(jobid)
-    FROM cron.job
-    WHERE jobname = 'schedule-live-activity';
-  END IF;
+  FOR r IN
+    SELECT id
+    FROM public.calendar_events
+    WHERE lower(trim(coalesce(type, ''))) = 'event'
+      AND end_time > now()
+  LOOP
+    PERFORM public.sync_event_live_activity_jobs(r.id);
+  END LOOP;
 END $$;
-
-SELECT cron.schedule(
-  'schedule-live-activity',
-  '*/5 * * * *',
-  $$
-  SELECT net.http_post(
-    url := 'https://chrbvfaknykaycwumuba.supabase.co/functions/v1/schedule-live-activity',
-    headers := jsonb_build_object(
-      'Content-Type', 'application/json',
-      'x-cron-secret', coalesce(
-        (SELECT decrypted_secret FROM vault.decrypted_secrets
-         WHERE name = 'schedule_live_activity_cron_secret' LIMIT 1),
-        ''
-      )
-    ),
-    body := '{}'::jsonb
-  );
-  $$
-);

--- a/lib/features/calendar/domain/filter/event_schedule_filter.dart
+++ b/lib/features/calendar/domain/filter/event_schedule_filter.dart
@@ -1,5 +1,6 @@
 import '../../../../core/database/backend_enums.dart';
 import '../models/event_schedule.dart';
+import '../../live_activity/domain/schedule_live_activity_event.dart';
 import 'calendar_filters_state.dart';
 import 'calendar_filter_text.dart';
 
@@ -63,6 +64,70 @@ bool eventScheduleVisible({
 
   if (schedule.voices.isNotEmpty && filters.voices.isNotEmpty) {
     final labels = schedule.voices
+        .map((v) => normalizeCalendarFilterText(v.toBackend()))
+        .whereType<String>()
+        .toSet();
+    final hasMatch = labels.any(filters.voices.contains);
+    if (!hasMatch) return false;
+  }
+
+  return true;
+}
+
+/// Prüft, ob ein Event-Termin zum Profil des Nutzers passt (Chor/Stimme).
+bool calendarEventMatchesUserProfile({
+  required ScheduleLiveActivityEvent event,
+  required CalendarFiltersState filters,
+}) {
+  final userChoirs = filters.defaultChoirs;
+  final userVoices = filters.defaultVoices;
+
+  if (event.choirs.isEmpty && event.voices.isEmpty) {
+    return true;
+  }
+
+  var choirOk = true;
+  if (event.choirs.isNotEmpty) {
+    if (userChoirs.isEmpty) {
+      choirOk = false;
+    } else {
+      final labels = event.choirs
+          .map((c) => normalizeCalendarFilterText(c.toBackend()))
+          .whereType<String>()
+          .toSet();
+      choirOk = labels.any(userChoirs.contains);
+    }
+  }
+
+  if (!choirOk) return false;
+
+  if (event.voices.isEmpty) return true;
+
+  if (userVoices.isEmpty) return false;
+
+  final voiceLabels = event.voices
+      .map((v) => normalizeCalendarFilterText(v.toBackend()))
+      .whereType<String>()
+      .toSet();
+  return voiceLabels.any(userVoices.contains);
+}
+
+/// Filterlogik für Event-Termine (choir/voices) — Kalender-Filter.
+bool calendarEventVisible({
+  required ScheduleLiveActivityEvent event,
+  required CalendarFiltersState filters,
+}) {
+  if (event.choirs.isNotEmpty && filters.choirs.isNotEmpty) {
+    final labels = event.choirs
+        .map((c) => normalizeCalendarFilterText(c.toBackend()))
+        .whereType<String>()
+        .toSet();
+    final hasMatch = labels.any(filters.choirs.contains);
+    if (!hasMatch) return false;
+  }
+
+  if (event.voices.isNotEmpty && filters.voices.isNotEmpty) {
+    final labels = event.voices
         .map((v) => normalizeCalendarFilterText(v.toBackend()))
         .whereType<String>()
         .toSet();

--- a/lib/features/calendar/live_activity/data/schedule_live_activity_data_source.dart
+++ b/lib/features/calendar/live_activity/data/schedule_live_activity_data_source.dart
@@ -1,10 +1,13 @@
 import 'package:powersync/powersync.dart';
 import 'package:sqlite3/common.dart';
 
+import '../../../../core/database/backend_enums.dart';
+import '../../../../core/database/postgres_enum_array_codec.dart';
 import '../../../../core/database/powersync_schema.dart';
 import '../../../../core/time/app_date_time.dart';
 import '../../data/event_schedule_mapper.dart';
 import '../../domain/models/event_schedule.dart';
+import '../domain/schedule_live_activity_event.dart';
 
 /// Lokale Abfragen für Ablaufplan-Live-Activities.
 class ScheduleLiveActivityDataSource {
@@ -29,6 +32,52 @@ class ScheduleLiveActivityDataSource {
       ],
     );
     return rows.map((r) => r['event_id']!.toString()).toSet();
+  }
+
+  /// Event-Termine (type event) ohne Ablaufplan im Zeitraum.
+  Future<List<ScheduleLiveActivityEvent>> eventsWithoutSchedule({
+    required DateTime rangeStart,
+    required DateTime rangeEndExclusive,
+  }) async {
+    final rows = await _db.getAll(
+      '''
+      SELECT ce.id, ce.event_name, ce.location, ce.start_time, ce.end_time,
+             ce.choir, ce.voices
+      FROM $kCalendarEventsTable ce
+      WHERE ce.type = 'event'
+        AND ce.start_time >= ? AND ce.start_time < ?
+        AND NOT EXISTS (
+          SELECT 1 FROM $kEventSchedulesTable es WHERE es.event_id = ce.id
+        )
+      ORDER BY ce.start_time ASC
+      ''',
+      [
+        rangeStart.toUtc().toIso8601String(),
+        rangeEndExclusive.toUtc().toIso8601String(),
+      ],
+    );
+    return _mapEventRows(rows);
+  }
+
+  Future<ScheduleLiveActivityEvent?> eventWithoutScheduleById(
+    String eventId,
+  ) async {
+    final rows = await _db.getAll(
+      '''
+      SELECT ce.id, ce.event_name, ce.location, ce.start_time, ce.end_time,
+             ce.choir, ce.voices
+      FROM $kCalendarEventsTable ce
+      WHERE ce.id = ?
+        AND ce.type = 'event'
+        AND NOT EXISTS (
+          SELECT 1 FROM $kEventSchedulesTable es WHERE es.event_id = ce.id
+        )
+      LIMIT 1
+      ''',
+      [eventId],
+    );
+    if (rows.isEmpty) return null;
+    return _mapEventRows(rows).firstOrNull;
   }
 
   Future<List<EventSchedule>> schedulesForEvent(String eventId) async {
@@ -83,6 +132,20 @@ class ScheduleLiveActivityDataSource {
     return out;
   }
 
+  /// Termin-Starts ohne Ablaufplan für lokale Notification-Planung.
+  Future<List<({String eventId, DateTime start})>> upcomingEventStarts({
+    required DateTime rangeStart,
+    required DateTime rangeEndExclusive,
+  }) async {
+    final events = await eventsWithoutSchedule(
+      rangeStart: rangeStart,
+      rangeEndExclusive: rangeEndExclusive,
+    );
+    return events
+        .map((event) => (eventId: event.id, start: event.startTime))
+        .toList();
+  }
+
   Stream<void> watchScheduleChanges() {
     return _db.watch(
       'SELECT COUNT(*) AS c FROM $kEventSchedulesTable',
@@ -99,4 +162,82 @@ class ScheduleLiveActivityDataSource {
     }
     return out;
   }
+
+  List<ScheduleLiveActivityEvent> _mapEventRows(ResultSet rows) {
+    final out = <ScheduleLiveActivityEvent>[];
+    for (final row in rows) {
+      try {
+        out.add(_eventFromRow(row));
+      } catch (_) {}
+    }
+    return out;
+  }
+
+  ScheduleLiveActivityEvent _eventFromRow(Row row) {
+    final startRaw = row['start_time']?.toString();
+    final endRaw = row['end_time']?.toString();
+    if (startRaw == null ||
+        startRaw.trim().isEmpty ||
+        endRaw == null ||
+        endRaw.trim().isEmpty) {
+      throw FormatException('calendar_events start/end fehlt');
+    }
+
+    final startTime = AppDateTime.asUtcInstant(
+      AppDateTime.parseDatabaseDateTime(
+        startRaw,
+        assumeUtcWhenTimezoneMissing: true,
+      ),
+    );
+    final endTime = AppDateTime.asUtcInstant(
+      AppDateTime.parseDatabaseDateTime(
+        endRaw,
+        assumeUtcWhenTimezoneMissing: true,
+      ),
+    );
+
+    return ScheduleLiveActivityEvent(
+      id: row['id']!.toString(),
+      eventName: row['event_name']?.toString().trim() ?? '',
+      location: _nullableTrim(row['location']?.toString()),
+      startTime: startTime,
+      endTime: endTime,
+      choirs: _parseChoirs(row['choir']),
+      voices: _parseVoices(row['voices']),
+    );
+  }
+
+  static String? _nullableTrim(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    return trimmed;
+  }
+
+  static List<BackendChoir> _parseChoirs(Object? raw) {
+    final tokens = PostgresEnumArrayCodec.decodeTokens(raw?.toString());
+    final out = <BackendChoir>[];
+    for (final token in tokens) {
+      final parsed = BackendChoirCodec.fromBackend(token);
+      if (parsed != BackendChoir.unknown && !out.contains(parsed)) {
+        out.add(parsed);
+      }
+    }
+    return out;
+  }
+
+  static List<BackendVoice> _parseVoices(Object? raw) {
+    final tokens = PostgresEnumArrayCodec.decodeTokens(raw?.toString());
+    final out = <BackendVoice>[];
+    for (final token in tokens) {
+      final parsed = BackendVoiceCodec.fromBackend(token);
+      if (parsed != BackendVoice.unknown && !out.contains(parsed)) {
+        out.add(parsed);
+      }
+    }
+    return out;
+  }
+}
+
+extension _FirstOrNull<T> on List<T> {
+  T? get firstOrNull => isEmpty ? null : first;
 }

--- a/lib/features/calendar/live_activity/data/schedule_live_activity_local_scheduler.dart
+++ b/lib/features/calendar/live_activity/data/schedule_live_activity_local_scheduler.dart
@@ -88,6 +88,7 @@ class ScheduleLiveActivityLocalScheduler {
   Future<void> rescheduleSegments({
     required List<({String eventId, String scheduleId, DateTime start})>
         segments,
+    List<({String eventId, DateTime start})> eventStarts = const [],
   }) async {
     if (!_initialized) return;
 
@@ -100,43 +101,69 @@ class ScheduleLiveActivityLocalScheduler {
     );
 
     for (final segment in segments) {
-      final localStart = AppDateTime.toLocal(segment.start);
-      if (!localStart.isAfter(now)) continue;
-      if (!localStart.isBefore(rangeEnd)) continue;
+      await _scheduleStartNotification(
+        eventId: segment.eventId,
+        scheduleId: segment.scheduleId,
+        start: segment.start,
+        now: now,
+        rangeEnd: rangeEnd,
+      );
+    }
 
-      final tzTime = tz.TZDateTime.from(localStart, tz.local);
-      final id = notificationIdFor(segment.eventId, segment.scheduleId);
-      final payload = '${segment.eventId}|${segment.scheduleId}';
+    for (final eventStart in eventStarts) {
+      await _scheduleStartNotification(
+        eventId: eventStart.eventId,
+        scheduleId: eventStart.eventId,
+        start: eventStart.start,
+        now: now,
+        rangeEnd: rangeEnd,
+      );
+    }
+  }
 
-      try {
-        await _plugin.zonedSchedule(
-          id,
-          null,
-          null,
-          tzTime,
-          NotificationDetails(
-            android: AndroidNotificationDetails(
-              channelId,
-              channelName,
-              importance: Importance.low,
-              priority: Priority.low,
-              playSound: false,
-              silent: true,
-              channelShowBadge: false,
-            ),
-            iOS: const DarwinNotificationDetails(
-              presentAlert: false,
-              presentSound: false,
-              presentBadge: false,
-            ),
+  Future<void> _scheduleStartNotification({
+    required String eventId,
+    required String scheduleId,
+    required DateTime start,
+    required DateTime now,
+    required DateTime rangeEnd,
+  }) async {
+    final localStart = AppDateTime.toLocal(start);
+    if (!localStart.isAfter(now)) return;
+    if (!localStart.isBefore(rangeEnd)) return;
+
+    final tzTime = tz.TZDateTime.from(localStart, tz.local);
+    final id = notificationIdFor(eventId, scheduleId);
+    final payload = '$eventId|$scheduleId';
+
+    try {
+      await _plugin.zonedSchedule(
+        id,
+        null,
+        null,
+        tzTime,
+        NotificationDetails(
+          android: AndroidNotificationDetails(
+            channelId,
+            channelName,
+            importance: Importance.low,
+            priority: Priority.low,
+            playSound: false,
+            silent: true,
+            channelShowBadge: false,
           ),
-          androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-          payload: payload,
-        );
-      } catch (e, st) {
-        if (kDebugMode) {
-          debugPrint('[LiveActivity] schedule failed: $e\n$st');
-        }
+          iOS: const DarwinNotificationDetails(
+            presentAlert: false,
+            presentSound: false,
+            presentBadge: false,
+          ),
+        ),
+        androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+        payload: payload,
+      );
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('[LiveActivity] schedule failed: $e\n$st');
       }
     }
   }

--- a/lib/features/calendar/live_activity/domain/schedule_live_activity_event.dart
+++ b/lib/features/calendar/live_activity/domain/schedule_live_activity_event.dart
@@ -1,0 +1,22 @@
+import '../../../../core/database/backend_enums.dart';
+
+/// Kalendertermin (type event) ohne Ablaufplan für Live-Activity-Zeitplanung.
+class ScheduleLiveActivityEvent {
+  const ScheduleLiveActivityEvent({
+    required this.id,
+    required this.eventName,
+    required this.startTime,
+    required this.endTime,
+    this.location,
+    this.choirs = const [],
+    this.voices = const [],
+  });
+
+  final String id;
+  final String eventName;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String? location;
+  final List<BackendChoir> choirs;
+  final List<BackendVoice> voices;
+}

--- a/lib/features/calendar/live_activity/domain/schedule_live_activity_resolver.dart
+++ b/lib/features/calendar/live_activity/domain/schedule_live_activity_resolver.dart
@@ -2,6 +2,7 @@ import 'package:chronoapp/core/time/app_date_time.dart';
 import 'package:chronoapp/features/calendar/domain/filter/event_schedule_filter.dart';
 import 'package:chronoapp/features/calendar/domain/filter/calendar_filters_state.dart';
 import 'package:chronoapp/features/calendar/domain/models/event_schedule.dart';
+import 'package:chronoapp/features/calendar/live_activity/domain/schedule_live_activity_event.dart';
 import 'package:chronoapp/features/calendar/live_activity/domain/schedule_live_activity_snapshot.dart';
 import 'package:chronoapp/features/calendar/live_activity/live_activity_constants.dart';
 import 'package:chronoapp/features/calendar/presentation/widgets/event_list/calendar_now_anchor.dart';
@@ -58,6 +59,50 @@ abstract final class ScheduleLiveActivityResolver {
       segmentStartMs: segmentStart.millisecondsSinceEpoch,
       segmentEndMs: segmentEnd.millisecondsSinceEpoch,
     );
+  }
+
+  /// Live Activity für Event-Termine ohne Ablaufplan.
+  static ScheduleLiveActivitySnapshot? resolveFromEvent({
+    required ScheduleLiveActivityEvent event,
+    required CalendarFiltersState filters,
+    DateTime? now,
+  }) {
+    final clock = now ?? DateTime.now();
+    if (!calendarEventVisible(event: event, filters: filters)) {
+      return null;
+    }
+    if (!AppDateTime.isTodayLocal(event.startTime, now: clock)) {
+      return null;
+    }
+    if (AppDateTime.isPastInstant(event.endTime, now: clock)) {
+      return null;
+    }
+    if (AppDateTime.toLocal(event.startTime).isAfter(clock)) {
+      return null;
+    }
+
+    final segmentStart = AppDateTime.toLocal(event.startTime);
+    final segmentEnd = AppDateTime.toLocal(event.endTime);
+
+    return ScheduleLiveActivitySnapshot(
+      eventId: event.id,
+      customId: liveActivityCustomIdForEvent(event.id),
+      currentScheduleId: event.id,
+      currentTitle: event.eventName,
+      currentSubtitle: event.location ?? '',
+      hasNext: false,
+      nextTitle: '',
+      nextSubtitle: '',
+      segmentStartMs: segmentStart.millisecondsSinceEpoch,
+      segmentEndMs: segmentEnd.millisecondsSinceEpoch,
+    );
+  }
+
+  static bool isEventFinished({
+    required ScheduleLiveActivityEvent event,
+    DateTime? now,
+  }) {
+    return AppDateTime.isPastInstant(event.endTime, now: now);
   }
 
   static int? _currentIndex(

--- a/lib/features/calendar/live_activity/presentation/schedule_live_activity_coordinator.dart
+++ b/lib/features/calendar/live_activity/presentation/schedule_live_activity_coordinator.dart
@@ -146,25 +146,39 @@ class ScheduleLiveActivityCoordinator {
       rangeStart: today,
       rangeEndExclusive: dayAfterTomorrow,
     );
+    final eventStarts = await _dataSource.upcomingEventStarts(
+      rangeStart: today,
+      rangeEndExclusive: dayAfterTomorrow,
+    );
 
     final dayEnds = await _computeDayEnds(
       dayStart: today,
       dayEndExclusive: dayAfterTomorrow,
     );
 
-    await _localScheduler.rescheduleSegments(segments: segments);
+    await _localScheduler.rescheduleSegments(
+      segments: segments,
+      eventStarts: eventStarts,
+    );
     await _localScheduler.rescheduleDayEnds(ends: dayEnds);
 
     _segmentTimerScheduler.reschedule(
-      starts: segments
-          .map(
-            (s) => (
-              eventId: s.eventId,
-              scheduleId: s.scheduleId,
-              at: AppDateTime.toLocal(s.start),
-            ),
-          )
-          .toList(),
+      starts: [
+        ...segments.map(
+          (s) => (
+            eventId: s.eventId,
+            scheduleId: s.scheduleId,
+            at: AppDateTime.toLocal(s.start),
+          ),
+        ),
+        ...eventStarts.map(
+          (s) => (
+            eventId: s.eventId,
+            scheduleId: s.eventId,
+            at: AppDateTime.toLocal(s.start),
+          ),
+        ),
+      ],
       dayEnds: dayEnds
           .map((e) => (eventId: e.eventId, at: AppDateTime.toLocal(e.end)))
           .toList(),
@@ -186,6 +200,10 @@ class ScheduleLiveActivityCoordinator {
     final eventIds = await _dataSource.eventIdsWithSchedulesOnDays(
       dayStart: dayStart,
       dayEndExclusive: dayEndExclusive,
+    );
+    final eventsWithoutSchedule = await _dataSource.eventsWithoutSchedule(
+      rangeStart: dayStart,
+      rangeEndExclusive: dayEndExclusive,
     );
 
     final filters = _ref.read(calendarFiltersProvider);
@@ -224,6 +242,16 @@ class ScheduleLiveActivityCoordinator {
       ));
     }
 
+    for (final event in eventsWithoutSchedule) {
+      if (!AppDateTime.isTodayLocal(event.startTime, now: now)) continue;
+      if (listFilter == EventScheduleListFilter.mine &&
+          !calendarEventMatchesUserProfile(event: event, filters: filters)) {
+        continue;
+      }
+      if (!calendarEventVisible(event: event, filters: filters)) continue;
+      ends.add((eventId: event.id, end: event.endTime));
+    }
+
     return ends;
   }
 
@@ -253,6 +281,10 @@ class ScheduleLiveActivityCoordinator {
     final eventIds = await _dataSource.eventIdsWithSchedulesOnDays(
       dayStart: today,
       dayEndExclusive: dayAfterTomorrow,
+    );
+    final eventsWithoutSchedule = await _dataSource.eventsWithoutSchedule(
+      rangeStart: today,
+      rangeEndExclusive: dayAfterTomorrow,
     );
 
     final filters = _ref.read(calendarFiltersProvider);
@@ -288,6 +320,31 @@ class ScheduleLiveActivityCoordinator {
       }
     }
 
+    for (final event in eventsWithoutSchedule) {
+      final customId = liveActivityCustomIdForEvent(event.id);
+      if (listFilter == EventScheduleListFilter.mine &&
+          !calendarEventMatchesUserProfile(event: event, filters: filters)) {
+        continue;
+      }
+
+      final snapshot = ScheduleLiveActivityResolver.resolveFromEvent(
+        event: event,
+        filters: filters,
+        now: now,
+      );
+
+      if (snapshot != null) {
+        stillActive.add(customId);
+        await _applySnapshotIfNeeded(snapshot);
+        continue;
+      }
+
+      if (ScheduleLiveActivityResolver.isEventFinished(event: event, now: now) &&
+          _activeCustomIds.contains(customId)) {
+        await _service.end(customId);
+      }
+    }
+
     final ended = _activeCustomIds.difference(stillActive).toList();
     for (final customId in ended) {
       await _service.end(customId);
@@ -304,16 +361,34 @@ class ScheduleLiveActivityCoordinator {
       _syncAgain = true;
       return;
     }
-    final schedules = await _dataSource.schedulesForEvent(eventId);
+
     final filters = _ref.read(calendarFiltersProvider);
     final listFilter = _ref.read(scheduleListFilterProvider).value ??
         EventScheduleListFilter.all;
-    final snapshot = ScheduleLiveActivityResolver.resolve(
-      eventId: eventId,
-      schedules: schedules,
-      listFilter: listFilter,
-      filters: filters,
-    );
+
+    final schedules = await _dataSource.schedulesForEvent(eventId);
+    ScheduleLiveActivitySnapshot? snapshot;
+    if (schedules.isNotEmpty) {
+      snapshot = ScheduleLiveActivityResolver.resolve(
+        eventId: eventId,
+        schedules: schedules,
+        listFilter: listFilter,
+        filters: filters,
+      );
+    } else {
+      final event = await _dataSource.eventWithoutScheduleById(eventId);
+      if (event != null) {
+        if (listFilter == EventScheduleListFilter.mine &&
+            !calendarEventMatchesUserProfile(event: event, filters: filters)) {
+          return;
+        }
+        snapshot = ScheduleLiveActivityResolver.resolveFromEvent(
+          event: event,
+          filters: filters,
+        );
+      }
+    }
+
     if (snapshot == null) return;
     await _applySnapshot(snapshot);
     _activeCustomIds.add(snapshot.customId);

--- a/supabase/functions/schedule-live-activity/index.ts
+++ b/supabase/functions/schedule-live-activity/index.ts
@@ -1,6 +1,7 @@
 /**
- * pg_cron → FCM Live Activities (start/end an Segmentgrenzen).
- * DB-Trigger (calendar_events, event_schedules) → FCM update/end bei Inhaltsänderungen.
+ * Bedarfsgesteuerte FCM Live Activities für Kalender-Events (type = event).
+ * DB-Trigger + geplante pg_cron-Einmal-Jobs → start/end an Termin-/Segmentgrenzen.
+ * DB-Trigger bei Änderungen → FCM update/end bei laufender Live Activity.
  *
  * Countdown läuft nativ auf dem Gerät (iOS TimelineView / Android Chronometer).
  * Server sendet nur: start (Push-to-Start), update (Inhaltsänderung), end.
@@ -37,6 +38,9 @@ type ScheduleRow = {
 type CalendarEventRow = {
   id: string;
   event_name: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  location?: string | null;
   choir: AudienceTokens;
   voices: AudienceTokens;
   type: string | null;
@@ -71,9 +75,12 @@ type Snapshot = {
   segmentEndMs: number;
 };
 
-type ChangeRequest = {
+type RequestBody = {
   mode?: string;
   event_id?: string;
+  schedule_id?: string | null;
+  action?: string;
+  job_id?: string;
   op?: string;
   source?: string;
   event_snapshot?: CalendarEventRow;
@@ -84,6 +91,10 @@ type SendOptions = {
   dedupAction?: LiveActivityFcmEvent;
   dispatchCache?: DispatchCache;
 };
+
+function isEventType(raw: string | null | undefined): boolean {
+  return (raw ?? "").trim().toLowerCase() === "event";
+}
 
 function dispatchKey(
   scheduleId: string,
@@ -176,7 +187,6 @@ class DispatchCache {
 
 function resolveSegmentStartEvent(device: DeviceRow): LiveActivityFcmEvent {
   const liveToken = device.live_activity_push_token?.trim();
-  // Bereits laufende Activity → nur Inhalt aktualisieren, kein erneutes Push-to-Start.
   return liveToken && liveToken.length > 0 ? "update" : "start";
 }
 
@@ -304,6 +314,25 @@ function hasSchedulesToday(schedules: ScheduleRow[], now: Date): boolean {
   return schedules.some((s) => isSameLocalDay(new Date(s.start_time), now));
 }
 
+function isEventActiveToday(event: CalendarEventRow, now: Date): boolean {
+  if (!event.start_time || !event.end_time) return false;
+  const start = new Date(event.start_time);
+  const end = new Date(event.end_time);
+  return isSameLocalDay(start, now) && start <= now && end > now;
+}
+
+function isEventRelevantToday(
+  event: CalendarEventRow,
+  schedules: ScheduleRow[],
+  now: Date,
+): boolean {
+  if (schedules.length > 0) {
+    return hasSchedulesToday(schedules, now);
+  }
+  if (!event.start_time || !event.end_time) return false;
+  return isSameLocalDay(new Date(event.start_time), now);
+}
+
 function buildSnapshot(
   schedules: ScheduleRow[],
   now: Date,
@@ -344,6 +373,22 @@ function buildSnapshot(
   };
 }
 
+function buildEventOnlySnapshot(
+  event: CalendarEventRow,
+): Snapshot | null {
+  if (!event.start_time || !event.end_time) return null;
+  return {
+    currentScheduleId: event.id,
+    currentTitle: event.event_name ?? "",
+    currentSubtitle: event.location ?? "",
+    hasNext: false,
+    nextTitle: "",
+    nextSubtitle: "",
+    segmentStartMs: new Date(event.start_time).getTime(),
+    segmentEndMs: new Date(event.end_time).getTime(),
+  };
+}
+
 function snapshotToContentState(
   snapshot: Snapshot,
   eventId: string,
@@ -360,6 +405,19 @@ function snapshotToContentState(
   };
 }
 
+function emptyContentState(eventId: string): Record<string, string | number | boolean> {
+  return {
+    currentTitle: "",
+    currentSubtitle: "",
+    hasNext: false,
+    nextTitle: "",
+    nextSubtitle: "",
+    segmentStartMs: 0,
+    segmentEndMs: 0,
+    eventId,
+  };
+}
+
 function isLastVisibleSegmentOfDay(
   schedule: ScheduleRow,
   visibleToday: ScheduleRow[],
@@ -368,42 +426,11 @@ function isLastVisibleSegmentOfDay(
   return visibleToday[visibleToday.length - 1].id === schedule.id;
 }
 
-async function wasDispatched(
-  supabase: ReturnType<typeof createClient>,
-  scheduleId: string,
-  userId: string,
-  deviceId: string,
-  action: LiveActivityFcmEvent,
-): Promise<boolean> {
-  const { data, error } = await supabase
-    .from("schedule_live_activity_dispatches")
-    .select("id")
-    .eq("schedule_id", scheduleId)
-    .eq("user_id", userId)
-    .eq("device_id", deviceId)
-    .eq("action", action)
-    .maybeSingle();
-  if (error) {
-    console.error("dispatch lookup failed", error.message);
-    return true;
-  }
-  return data != null;
-}
-
-async function markDispatched(
-  supabase: ReturnType<typeof createClient>,
-  scheduleId: string,
-  userId: string,
-  deviceId: string,
-  action: LiveActivityFcmEvent,
-): Promise<void> {
-  await supabase.from("schedule_live_activity_dispatches").upsert({
-    schedule_id: scheduleId,
-    user_id: userId,
-    device_id: deviceId,
-    action,
-    sent_at: new Date().toISOString(),
-  }, { onConflict: "schedule_id,user_id,device_id,action" });
+function dedupScheduleId(
+  eventId: string,
+  scheduleId: string | null | undefined,
+): string {
+  return scheduleId?.trim() ? scheduleId : eventId;
 }
 
 async function sendForDevice(
@@ -422,13 +449,7 @@ async function sendForDevice(
   if (!options?.skipDedup) {
     const alreadySent = cache
       ? cache.wasDispatched(scheduleId, device.user_id, device.device_id, dedupAction)
-      : await wasDispatched(
-        supabase,
-        scheduleId,
-        device.user_id,
-        device.device_id,
-        dedupAction,
-      );
+      : false;
     if (alreadySent) return "skipped";
   }
 
@@ -449,22 +470,12 @@ async function sendForDevice(
 
   if (result.ok) {
     if (!options?.skipDedup) {
-      if (cache) {
-        cache.markDispatched(
-          scheduleId,
-          device.user_id,
-          device.device_id,
-          dedupAction,
-        );
-      } else {
-        await markDispatched(
-          supabase,
-          scheduleId,
-          device.user_id,
-          device.device_id,
-          dedupAction,
-        );
-      }
+      cache?.markDispatched(
+        scheduleId,
+        device.user_id,
+        device.device_id,
+        dedupAction,
+      );
     }
     return "sent";
   }
@@ -476,31 +487,9 @@ async function sendForDevice(
   return "failed";
 }
 
-async function loadSchedulesByEventIds(
+async function loadDevicesForEvent(
   supabase: ReturnType<typeof createClient>,
-  eventIds: string[],
-): Promise<Map<string, ScheduleRow[]>> {
-  const schedulesByEvent = new Map<string, ScheduleRow[]>();
-  if (eventIds.length === 0) return schedulesByEvent;
-
-  const { data: allSchedules, error } = await supabase
-    .from("event_schedules")
-    .select("id, event_id, title, location, start_time, end_time, choir, voices")
-    .in("event_id", eventIds)
-    .order("start_time", { ascending: true });
-
-  if (error || !allSchedules?.length) return schedulesByEvent;
-
-  for (const row of allSchedules as ScheduleRow[]) {
-    const list = schedulesByEvent.get(row.event_id) ?? [];
-    list.push(row);
-    schedulesByEvent.set(row.event_id, list);
-  }
-  return schedulesByEvent;
-}
-
-async function loadDevices(
-  supabase: ReturnType<typeof createClient>,
+  event: CalendarEventRow,
 ): Promise<DeviceRow[]> {
   const { data: devices, error: devicesError } = await supabase
     .from("profile_push_devices")
@@ -517,77 +506,106 @@ async function loadDevices(
     throw new Error(devicesError.message);
   }
 
-  return (devices ?? []) as DeviceRow[];
+  return ((devices ?? []) as DeviceRow[]).filter((device) => {
+    const profile = asProfile(device.profiles);
+    return profile != null && profileMatchesEvent(profile, event);
+  });
 }
 
-async function handleContentChange(
+async function loadEvent(
   supabase: ReturnType<typeof createClient>,
-  serviceAccount: ReturnType<typeof parseServiceAccountJson>,
-  request: ChangeRequest,
-  now: Date,
-): Promise<Response> {
-  const eventId = request.event_id;
-  if (!eventId) {
-    return jsonResponse({ error: "event_id required" }, 400);
+  eventId: string,
+  snapshot?: CalendarEventRow | null,
+): Promise<CalendarEventRow | null> {
+  if (snapshot?.id) return snapshot;
+
+  const { data, error } = await supabase
+    .from("calendar_events")
+    .select("id, event_name, start_time, end_time, location, choir, voices, type")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("calendar_events lookup failed", error.message);
+    throw new Error(error.message);
   }
 
-  let event: CalendarEventRow | null = null;
-  if (request.op === "DELETE" && request.event_snapshot?.id) {
-    event = request.event_snapshot;
-  } else {
-    const { data, error } = await supabase
-      .from("calendar_events")
-      .select("id, event_name, choir, voices, type")
-      .eq("id", eventId)
-      .maybeSingle();
-    if (error) {
-      console.error("calendar_events lookup failed", error.message);
-      return jsonResponse({ error: "Query failed", detail: error.message }, 500);
-    }
-    event = data as CalendarEventRow | null;
-  }
+  return data as CalendarEventRow | null;
+}
 
-  const { data: allSchedules, error: schedulesError } = await supabase
+async function loadSchedulesForEvent(
+  supabase: ReturnType<typeof createClient>,
+  eventId: string,
+): Promise<ScheduleRow[]> {
+  const { data, error } = await supabase
     .from("event_schedules")
     .select("id, event_id, title, location, start_time, end_time, choir, voices")
     .eq("event_id", eventId)
     .order("start_time", { ascending: true });
 
-  if (schedulesError) {
-    console.error("event_schedules query failed", schedulesError.message);
-    return jsonResponse({ error: "Query failed", detail: schedulesError.message }, 500);
+  if (error) {
+    console.error("event_schedules query failed", error.message);
+    throw new Error(error.message);
   }
 
-  const schedules = (allSchedules ?? []) as ScheduleRow[];
+  return (data ?? []) as ScheduleRow[];
+}
 
-  if (request.op === "DELETE" && !hasSchedulesToday(schedules, now)) {
-    return jsonResponse({ processed: 1, sent: 0, skipped: 0, mode: "change" });
+async function handleDispatch(
+  supabase: ReturnType<typeof createClient>,
+  serviceAccount: ReturnType<typeof parseServiceAccountJson>,
+  request: RequestBody,
+  now: Date,
+): Promise<Response> {
+  const eventId = request.event_id;
+  const action = request.action;
+  if (!eventId || (action !== "start" && action !== "end")) {
+    return jsonResponse({ error: "event_id and action (start|end) required" }, 400);
   }
 
-  if (request.op !== "DELETE" && !hasSchedulesToday(schedules, now)) {
-    return jsonResponse({ processed: 1, sent: 0, skipped: 0, mode: "change" });
+  let event: CalendarEventRow | null;
+  try {
+    event = await loadEvent(supabase, eventId);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return jsonResponse({ error: "Query failed", detail: message }, 500);
   }
+
+  if (!event || !isEventType(event.type)) {
+    return jsonResponse({ processed: 0, sent: 0, skipped: 0, mode: "dispatch" });
+  }
+
+  let schedules: ScheduleRow[];
+  try {
+    schedules = await loadSchedulesForEvent(supabase, eventId);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return jsonResponse({ error: "Query failed", detail: message }, 500);
+  }
+
+  const hasSchedules = schedules.length > 0;
+  const scheduleId = dedupScheduleId(eventId, request.schedule_id);
 
   let devices: DeviceRow[];
   try {
-    devices = await loadDevices(supabase);
+    devices = await loadDevicesForEvent(supabase, event);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return jsonResponse({ error: "Query failed", step: "profile_push_devices", detail: message }, 500);
   }
 
-  const scheduleIds = schedules.map((schedule) => schedule.id);
+  const dispatchScheduleIds = hasSchedules
+    ? schedules.map((s) => s.id)
+    : [eventId];
   const dispatchCache = await DispatchCache.load(
     supabase,
-    scheduleIds,
+    dispatchScheduleIds,
     ["start", "end"],
   );
 
   let sent = 0;
   let failed = 0;
   let skipped = 0;
-
-  const isDeleted = request.op === "DELETE" || event == null;
 
   for (const device of devices) {
     const profile = asProfile(device.profiles);
@@ -596,32 +614,71 @@ async function handleContentChange(
       continue;
     }
 
-    if (isDeleted) {
-      if (!event || !profileMatchesEvent(profile, event)) {
+    const filter = device.schedule_filter ?? "all";
+
+    if (!hasSchedules) {
+      const snapshot = buildEventOnlySnapshot(event);
+      if (!snapshot) {
         skipped++;
         continue;
       }
-      const lastScheduleId = schedules.length > 0
-        ? schedules[schedules.length - 1].id
-        : eventId;
+
+      if (action === "start") {
+        const fcmEvent = resolveSegmentStartEvent(device);
+        const result = await sendForDevice(
+          supabase,
+          serviceAccount,
+          device,
+          eventId,
+          eventId,
+          fcmEvent,
+          snapshotToContentState(snapshot, eventId),
+          { dispatchCache, dedupAction: "start" },
+        );
+        if (result === "sent") sent++;
+        else if (result === "failed") failed++;
+        else skipped++;
+      } else {
+        const result = await sendForDevice(
+          supabase,
+          serviceAccount,
+          device,
+          eventId,
+          eventId,
+          "end",
+          snapshotToContentState(snapshot, eventId),
+          { dispatchCache },
+        );
+        if (result === "sent") sent++;
+        else if (result === "failed") failed++;
+        else skipped++;
+      }
+      continue;
+    }
+
+    const visible = visibleSchedulesToday(schedules, profile, filter, now);
+    const targetSchedule = schedules.find((s) => s.id === scheduleId);
+
+    if (action === "start") {
+      if (!targetSchedule) {
+        skipped++;
+        continue;
+      }
+      const snapshot = buildSnapshot(visible, now);
+      if (!snapshot || snapshot.currentScheduleId !== targetSchedule.id) {
+        skipped++;
+        continue;
+      }
+      const fcmEvent = resolveSegmentStartEvent(device);
       const result = await sendForDevice(
         supabase,
         serviceAccount,
         device,
         eventId,
-        lastScheduleId,
-        "end",
-        {
-          currentTitle: "",
-          currentSubtitle: "",
-          hasNext: false,
-          nextTitle: "",
-          nextSubtitle: "",
-          segmentStartMs: 0,
-          segmentEndMs: 0,
-          eventId,
-        },
-        { skipDedup: true },
+        targetSchedule.id,
+        fcmEvent,
+        snapshotToContentState(snapshot, eventId),
+        { dispatchCache, dedupAction: "start" },
       );
       if (result === "sent") sent++;
       else if (result === "failed") failed++;
@@ -629,27 +686,146 @@ async function handleContentChange(
       continue;
     }
 
-    if (!profileMatchesEvent(profile, event)) {
-      const lastScheduleId = schedules.length > 0
-        ? schedules[schedules.length - 1].id
-        : eventId;
+    if (!targetSchedule) {
+      skipped++;
+      continue;
+    }
+    if (!isLastVisibleSegmentOfDay(targetSchedule, visible)) {
+      skipped++;
+      continue;
+    }
+
+    const last = visible[visible.length - 1];
+    const contentState = snapshotToContentState({
+      currentScheduleId: last.id,
+      currentTitle: last.title,
+      currentSubtitle: last.location ?? "",
+      hasNext: false,
+      nextTitle: "",
+      nextSubtitle: "",
+      segmentStartMs: new Date(last.start_time).getTime(),
+      segmentEndMs: effectiveEnd(last).getTime(),
+    }, eventId);
+
+    const result = await sendForDevice(
+      supabase,
+      serviceAccount,
+      device,
+      eventId,
+      targetSchedule.id,
+      "end",
+      contentState,
+      { dispatchCache },
+    );
+    if (result === "sent") sent++;
+    else if (result === "failed") failed++;
+    else skipped++;
+  }
+
+  await dispatchCache.flush(supabase);
+
+  return jsonResponse({
+    processed: 1,
+    sent,
+    failed,
+    skipped,
+    mode: "dispatch",
+    event_id: eventId,
+    action,
+    schedule_id: request.schedule_id ?? null,
+    job_id: request.job_id ?? null,
+  });
+}
+
+async function handleContentChange(
+  supabase: ReturnType<typeof createClient>,
+  serviceAccount: ReturnType<typeof parseServiceAccountJson>,
+  request: RequestBody,
+  now: Date,
+): Promise<Response> {
+  const eventId = request.event_id;
+  if (!eventId) {
+    return jsonResponse({ error: "event_id required" }, 400);
+  }
+
+  let event: CalendarEventRow | null;
+  try {
+    event = await loadEvent(
+      supabase,
+      eventId,
+      request.op === "DELETE" ? request.event_snapshot : null,
+    );
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return jsonResponse({ error: "Query failed", detail: message }, 500);
+  }
+
+  if (event && !isEventType(event.type)) {
+    return jsonResponse({ processed: 0, sent: 0, skipped: 0, mode: "change" });
+  }
+
+  let schedules: ScheduleRow[];
+  try {
+    schedules = await loadSchedulesForEvent(supabase, eventId);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return jsonResponse({ error: "Query failed", detail: message }, 500);
+  }
+
+  const isDeleted = request.op === "DELETE" || event == null;
+  if (!isDeleted && event && !isEventRelevantToday(event, schedules, now)) {
+    return jsonResponse({ processed: 1, sent: 0, skipped: 0, mode: "change" });
+  }
+
+  if (isDeleted && !event) {
+    return jsonResponse({ processed: 1, sent: 0, skipped: 0, mode: "change" });
+  }
+
+  const referenceEvent = event!;
+  let devices: DeviceRow[];
+  try {
+    devices = isDeleted
+      ? await loadDevicesForEvent(supabase, referenceEvent)
+      : await loadDevicesForEvent(supabase, referenceEvent);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return jsonResponse({ error: "Query failed", step: "profile_push_devices", detail: message }, 500);
+  }
+
+  const hasSchedules = schedules.length > 0;
+  const dispatchScheduleIds = hasSchedules
+    ? schedules.map((s) => s.id)
+    : [eventId];
+  const dispatchCache = await DispatchCache.load(
+    supabase,
+    dispatchScheduleIds,
+    ["start", "end"],
+  );
+
+  let sent = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const device of devices) {
+    const profile = asProfile(device.profiles);
+    if (!profile) {
+      skipped++;
+      continue;
+    }
+
+    const endScheduleId = hasSchedules
+      ? schedules[schedules.length - 1].id
+      : eventId;
+
+    if (isDeleted || !profileMatchesEvent(profile, referenceEvent)) {
       const result = await sendForDevice(
         supabase,
         serviceAccount,
         device,
         eventId,
-        lastScheduleId,
+        endScheduleId,
         "end",
-        {
-          currentTitle: "",
-          currentSubtitle: "",
-          hasNext: false,
-          nextTitle: "",
-          nextSubtitle: "",
-          segmentStartMs: 0,
-          segmentEndMs: 0,
-          eventId,
-        },
+        emptyContentState(eventId),
         { skipDedup: true },
       );
       if (result === "sent") sent++;
@@ -659,6 +835,59 @@ async function handleContentChange(
     }
 
     const filter = device.schedule_filter ?? "all";
+
+    if (!hasSchedules) {
+      const snapshot = buildEventOnlySnapshot(referenceEvent);
+      if (!snapshot || !isEventActiveToday(referenceEvent, now)) {
+        if (snapshot && new Date(referenceEvent.end_time!) <= now) {
+          const result = await sendForDevice(
+            supabase,
+            serviceAccount,
+            device,
+            eventId,
+            eventId,
+            "end",
+            snapshotToContentState(snapshot, eventId),
+            { skipDedup: true },
+          );
+          if (result === "sent") sent++;
+          else if (result === "failed") failed++;
+          else skipped++;
+        } else {
+          skipped++;
+        }
+        continue;
+      }
+
+      const alreadyStarted = dispatchCache.wasDispatched(
+        eventId,
+        device.user_id,
+        device.device_id,
+        "start",
+      );
+      const fcmEvent: LiveActivityFcmEvent = alreadyStarted
+        ? "update"
+        : resolveSegmentStartEvent(device);
+      const result = await sendForDevice(
+        supabase,
+        serviceAccount,
+        device,
+        eventId,
+        eventId,
+        fcmEvent,
+        snapshotToContentState(snapshot, eventId),
+        {
+          dispatchCache,
+          skipDedup: fcmEvent === "update",
+          dedupAction: "start",
+        },
+      );
+      if (result === "sent") sent++;
+      else if (result === "failed") failed++;
+      else skipped++;
+      continue;
+    }
+
     const visible = visibleSchedulesToday(schedules, profile, filter, now);
     const snapshot = buildSnapshot(visible, now);
 
@@ -702,8 +931,6 @@ async function handleContentChange(
     const fcmEvent: LiveActivityFcmEvent = alreadyStarted
       ? "update"
       : resolveSegmentStartEvent(device);
-    const contentState = snapshotToContentState(snapshot, eventId);
-
     const result = await sendForDevice(
       supabase,
       serviceAccount,
@@ -711,7 +938,7 @@ async function handleContentChange(
       eventId,
       snapshot.currentScheduleId,
       fcmEvent,
-      contentState,
+      snapshotToContentState(snapshot, eventId),
       {
         dispatchCache,
         skipDedup: fcmEvent === "update",
@@ -737,243 +964,60 @@ async function handleContentChange(
   });
 }
 
-async function handleCronTick(
-  supabase: ReturnType<typeof createClient>,
-  serviceAccount: ReturnType<typeof parseServiceAccountJson>,
-  now: Date,
-): Promise<Response> {
-  const windowStart = new Date(now.getTime() - 30_000).toISOString();
-  const windowEnd = new Date(now.getTime() + 30_000).toISOString();
-
-  const { data: startingSchedules, error: scheduleError } = await supabase
-    .from("event_schedules")
-    .select("id, event_id, title, location, start_time, end_time, choir, voices")
-    .gte("start_time", windowStart)
-    .lte("start_time", windowEnd);
-
-  if (scheduleError) {
-    console.error("event_schedules query failed", scheduleError.message);
-    return jsonResponse({ error: "Query failed", step: "starting_schedules", detail: scheduleError.message }, 500);
-  }
-
-  const { data: endingSchedules, error: endingError } = await supabase
-    .from("event_schedules")
-    .select("id, event_id, title, location, start_time, end_time, choir, voices")
-    .or(
-      `and(end_time.gte."${windowStart}",end_time.lte."${windowEnd}"),and(end_time.is.null,start_time.gte."${windowStart}",start_time.lte."${windowEnd}")`,
-    );
-
-  if (endingError) {
-    console.error("ending schedules query failed", endingError.message);
-    return jsonResponse({ error: "Query failed", step: "ending_schedules", detail: endingError.message }, 500);
-  }
-
-  const eventIds = new Set<string>();
-  for (const row of [...(startingSchedules ?? []), ...(endingSchedules ?? [])]) {
-    eventIds.add(row.event_id);
-  }
-
-  if (eventIds.size === 0) {
-    return jsonResponse({ processed: 0, sent: 0, mode: "cron" });
-  }
-
-  const { data: events, error: eventsError } = await supabase
-    .from("calendar_events")
-    .select("id, event_name, choir, voices, type")
-    .in("id", [...eventIds]);
-
-  if (eventsError) {
-    console.error("calendar_events query failed", eventsError.message);
-    return jsonResponse({ error: "Query failed", step: "calendar_events", detail: eventsError.message }, 500);
-  }
-
-  const eventsById = new Map<string, CalendarEventRow>();
-  for (const event of events ?? []) {
-    eventsById.set(event.id, event as CalendarEventRow);
-  }
-
-  let devices: DeviceRow[];
-  try {
-    devices = await loadDevices(supabase);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    return jsonResponse({ error: "Query failed", step: "profile_push_devices", detail: message }, 500);
-  }
-
-  const schedulesByEvent = await loadSchedulesByEventIds(
-    supabase,
-    [...eventIds],
-  );
-
-  const scheduleIds = [
-    ...new Set(
-      [...schedulesByEvent.values()].flatMap((rows) => rows.map((row) => row.id)),
-    ),
-  ];
-  const dispatchCache = await DispatchCache.load(
-    supabase,
-    scheduleIds,
-    ["start", "end"],
-  );
-
-  let sent = 0;
-  let failed = 0;
-  let skipped = 0;
-
-  for (const startRow of (startingSchedules ?? []) as ScheduleRow[]) {
-    const event = eventsById.get(startRow.event_id);
-    if (!event) continue;
-
-    const allSchedules = schedulesByEvent.get(startRow.event_id);
-    if (!allSchedules?.length) continue;
-
-    for (const device of devices) {
-      const profile = asProfile(device.profiles);
-      if (!profile || !profileMatchesEvent(profile, event)) {
-        skipped++;
-        continue;
-      }
-
-      const filter = device.schedule_filter ?? "all";
-      const visible = visibleSchedulesToday(allSchedules, profile, filter, now);
-      const snapshot = buildSnapshot(visible, now);
-      if (!snapshot || snapshot.currentScheduleId !== startRow.id) {
-        skipped++;
-        continue;
-      }
-
-      const contentState = snapshotToContentState(snapshot, startRow.event_id);
-      const fcmEvent = resolveSegmentStartEvent(device);
-      const result = await sendForDevice(
-        supabase,
-        serviceAccount,
-        device,
-        startRow.event_id,
-        startRow.id,
-        fcmEvent,
-        contentState,
-        { dispatchCache, dedupAction: "start" },
-      );
-      if (result === "sent") sent++;
-      else if (result === "failed") failed++;
-      else skipped++;
-    }
-  }
-
-  for (const endRow of (endingSchedules ?? []) as ScheduleRow[]) {
-    const event = eventsById.get(endRow.event_id);
-    if (!event) continue;
-
-    const allSchedules = schedulesByEvent.get(endRow.event_id);
-    if (!allSchedules?.length) continue;
-
-    for (const device of devices) {
-      const profile = asProfile(device.profiles);
-      if (!profile || !profileMatchesEvent(profile, event)) {
-        skipped++;
-        continue;
-      }
-
-      const filter = device.schedule_filter ?? "all";
-      const visible = visibleSchedulesToday(allSchedules, profile, filter, now);
-      if (!isLastVisibleSegmentOfDay(endRow, visible)) {
-        skipped++;
-        continue;
-      }
-
-      const last = visible[visible.length - 1];
-      const contentState = snapshotToContentState({
-        currentScheduleId: last.id,
-        currentTitle: last.title,
-        currentSubtitle: last.location ?? "",
-        hasNext: false,
-        nextTitle: "",
-        nextSubtitle: "",
-        segmentStartMs: new Date(last.start_time).getTime(),
-        segmentEndMs: effectiveEnd(last).getTime(),
-      }, endRow.event_id);
-
-      const result = await sendForDevice(
-        supabase,
-        serviceAccount,
-        device,
-        endRow.event_id,
-        endRow.id,
-        "end",
-        contentState,
-        { dispatchCache },
-      );
-      if (result === "sent") sent++;
-      else if (result === "failed") failed++;
-      else skipped++;
-    }
-  }
-
-  await dispatchCache.flush(supabase);
-
-  return jsonResponse({
-    processed: eventIds.size,
-    sent,
-    failed,
-    skipped,
-    mode: "cron",
-  });
-}
-
 Deno.serve(async (req) => {
   try {
-  if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
-  }
-
-  if (req.method !== "POST") {
-    return jsonResponse({ error: "Method not allowed" }, 405);
-  }
-
-  const cronSecret = Deno.env.get("SCHEDULE_LIVE_ACTIVITY_CRON_SECRET");
-  const headerSecret = req.headers.get("x-cron-secret");
-  if (!cronSecret || headerSecret !== cronSecret) {
-    return jsonResponse({ error: "Unauthorized" }, 401);
-  }
-
-  const serviceAccountRaw = Deno.env.get("FIREBASE_SERVICE_ACCOUNT_JSON");
-  const supabaseUrl = Deno.env.get("SUPABASE_URL");
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  if (!serviceAccountRaw || !supabaseUrl || !serviceRoleKey) {
-    return jsonResponse({ error: "Server misconfigured" }, 500);
-  }
-
-  let serviceAccount;
-  try {
-    serviceAccount = parseServiceAccountJson(serviceAccountRaw);
-  } catch (e) {
-    console.error("Firebase service account parse error", e);
-    return jsonResponse({ error: "Server configuration error" }, 500);
-  }
-  const supabase = createClient(supabaseUrl, serviceRoleKey);
-  const now = new Date();
-
-  let changeRequest: ChangeRequest = {};
-  try {
-    const rawBody = await req.text();
-    if (rawBody.trim().length > 0) {
-      changeRequest = JSON.parse(rawBody) as ChangeRequest;
+    if (req.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders });
     }
-  } catch (e) {
-    console.error("request body parse error", e);
-    return jsonResponse({ error: "Invalid JSON body" }, 400);
-  }
 
-  if (changeRequest.mode === "change" && changeRequest.event_id) {
-    return await handleContentChange(
-      supabase,
-      serviceAccount,
-      changeRequest,
-      now,
-    );
-  }
+    if (req.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed" }, 405);
+    }
 
-  return await handleCronTick(supabase, serviceAccount, now);
+    const cronSecret = Deno.env.get("SCHEDULE_LIVE_ACTIVITY_CRON_SECRET");
+    const headerSecret = req.headers.get("x-cron-secret");
+    if (!cronSecret || headerSecret !== cronSecret) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    const serviceAccountRaw = Deno.env.get("FIREBASE_SERVICE_ACCOUNT_JSON");
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!serviceAccountRaw || !supabaseUrl || !serviceRoleKey) {
+      return jsonResponse({ error: "Server misconfigured" }, 500);
+    }
+
+    let serviceAccount;
+    try {
+      serviceAccount = parseServiceAccountJson(serviceAccountRaw);
+    } catch (e) {
+      console.error("Firebase service account parse error", e);
+      return jsonResponse({ error: "Server configuration error" }, 500);
+    }
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const now = new Date();
+
+    let body: RequestBody = {};
+    try {
+      const rawBody = await req.text();
+      if (rawBody.trim().length === 0) {
+        return jsonResponse({ error: "Request body required" }, 400);
+      }
+      body = JSON.parse(rawBody) as RequestBody;
+    } catch (e) {
+      console.error("request body parse error", e);
+      return jsonResponse({ error: "Invalid JSON body" }, 400);
+    }
+
+    if (body.mode === "dispatch" && body.event_id) {
+      return await handleDispatch(supabase, serviceAccount, body, now);
+    }
+
+    if (body.mode === "change" && body.event_id) {
+      return await handleContentChange(supabase, serviceAccount, body, now);
+    }
+
+    return jsonResponse({ error: "Invalid mode" }, 400);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     console.error("schedule-live-activity unhandled", e);

--- a/supabase/migrations/20260704120000_remove_schedule_live_activity_minute_cron.sql
+++ b/supabase/migrations/20260704120000_remove_schedule_live_activity_minute_cron.sql
@@ -1,0 +1,14 @@
+-- Entfernt den minütlichen Polling-Cron für schedule-live-activity.
+-- Dispatch-Zeitpunkte werden ab 20260704130000 bedarfsgesteuert geplant.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'schedule-live-activity') THEN
+    PERFORM cron.unschedule(jobid)
+    FROM cron.job
+    WHERE jobname = 'schedule-live-activity';
+  END IF;
+END $$;
+
+COMMENT ON EXTENSION pg_cron IS
+  'schedule-live-activity: kein globaler Minuten-Job mehr (bedarfsgesteuert via event_live_activity_jobs).';

--- a/supabase/migrations/20260704130000_event_live_activity_on_demand.sql
+++ b/supabase/migrations/20260704130000_event_live_activity_on_demand.sql
@@ -1,0 +1,423 @@
+-- Bedarfsgesteuertes Scheduling für Event-Live-Activities (type = event).
+-- Ersetzt den minütlichen pg_cron-Polling-Job durch Einmal-Jobs pro Start/Ende.
+
+CREATE TABLE IF NOT EXISTS public.event_live_activity_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id uuid NOT NULL,
+  schedule_id uuid,
+  action text NOT NULL CHECK (action IN ('start', 'end')),
+  run_at timestamptz NOT NULL,
+  cron_jobname text NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS event_live_activity_jobs_event_schedule_action_idx
+  ON public.event_live_activity_jobs (
+    event_id,
+    COALESCE(schedule_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    action
+  );
+
+CREATE INDEX IF NOT EXISTS event_live_activity_jobs_event_id_idx
+  ON public.event_live_activity_jobs (event_id);
+
+CREATE INDEX IF NOT EXISTS event_live_activity_jobs_run_at_idx
+  ON public.event_live_activity_jobs (run_at);
+
+COMMENT ON TABLE public.event_live_activity_jobs IS
+  'Geplante Einmal-Dispatches für Event-Live-Activities (pg_cron → Edge Function).';
+
+CREATE OR REPLACE FUNCTION public._timestamptz_to_cron_expr(p_at timestamptz)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT format(
+    '%s %s %s %s *',
+    EXTRACT(MINUTE FROM p_at AT TIME ZONE 'UTC')::int,
+    EXTRACT(HOUR FROM p_at AT TIME ZONE 'UTC')::int,
+    EXTRACT(DAY FROM p_at AT TIME ZONE 'UTC')::int,
+    EXTRACT(MONTH FROM p_at AT TIME ZONE 'UTC')::int
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public._clear_event_live_activity_jobs(p_event_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, cron
+AS $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT cron_jobname
+    FROM public.event_live_activity_jobs
+    WHERE event_id = p_event_id
+  LOOP
+    BEGIN
+      PERFORM cron.unschedule(r.cron_jobname);
+    EXCEPTION
+      WHEN OTHERS THEN NULL;
+    END;
+  END LOOP;
+
+  DELETE FROM public.event_live_activity_jobs
+  WHERE event_id = p_event_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public._schedule_event_live_activity_job(
+  p_event_id uuid,
+  p_schedule_id uuid,
+  p_action text,
+  p_run_at timestamptz
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, cron, vault
+AS $$
+DECLARE
+  v_job_id uuid;
+  v_jobname text;
+  v_cron_expr text;
+  v_secret text;
+  v_body jsonb;
+BEGIN
+  IF p_run_at <= now() THEN
+    RETURN;
+  END IF;
+
+  v_job_id := gen_random_uuid();
+  v_jobname := 'sla-' || replace(v_job_id::text, '-', '');
+  v_cron_expr := public._timestamptz_to_cron_expr(p_run_at);
+
+  v_body := jsonb_build_object(
+    'mode', 'dispatch',
+    'event_id', p_event_id,
+    'action', p_action,
+    'job_id', v_job_id
+  );
+  IF p_schedule_id IS NOT NULL THEN
+    v_body := v_body || jsonb_build_object('schedule_id', p_schedule_id);
+  END IF;
+
+  SELECT decrypted_secret INTO v_secret
+  FROM vault.decrypted_secrets
+  WHERE name = 'schedule_live_activity_cron_secret'
+  LIMIT 1;
+
+  IF v_secret IS NULL OR v_secret = '' THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.event_live_activity_jobs (
+    id, event_id, schedule_id, action, run_at, cron_jobname
+  ) VALUES (
+    v_job_id, p_event_id, p_schedule_id, p_action, p_run_at, v_jobname
+  );
+
+  PERFORM cron.schedule(
+    v_jobname,
+    v_cron_expr,
+    format(
+      $job$
+      SELECT net.http_post(
+        url := 'https://chrbvfaknykaycwumuba.supabase.co/functions/v1/schedule-live-activity',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'x-cron-secret', %L
+        ),
+        body := %L::jsonb
+      );
+      SELECT cron.unschedule(%L);
+      DELETE FROM public.event_live_activity_jobs WHERE id = %L::uuid;
+      $job$,
+      v_secret,
+      v_body::text,
+      v_jobname,
+      v_job_id
+    )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_event_live_activity_jobs(p_event_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event record;
+  v_schedule record;
+  v_schedule_count int;
+  v_end_at timestamptz;
+BEGIN
+  PERFORM public._clear_event_live_activity_jobs(p_event_id);
+
+  SELECT id, type, start_time, end_time
+  INTO v_event
+  FROM public.calendar_events
+  WHERE id = p_event_id;
+
+  IF NOT FOUND OR lower(trim(coalesce(v_event.type, ''))) <> 'event' THEN
+    RETURN;
+  END IF;
+
+  SELECT count(*) INTO v_schedule_count
+  FROM public.event_schedules
+  WHERE event_id = p_event_id;
+
+  IF v_schedule_count = 0 THEN
+    PERFORM public._schedule_event_live_activity_job(
+      p_event_id, NULL, 'start', v_event.start_time
+    );
+    PERFORM public._schedule_event_live_activity_job(
+      p_event_id, NULL, 'end', v_event.end_time
+    );
+    RETURN;
+  END IF;
+
+  FOR v_schedule IN
+    SELECT id, start_time, end_time
+    FROM public.event_schedules
+    WHERE event_id = p_event_id
+    ORDER BY start_time ASC
+  LOOP
+    PERFORM public._schedule_event_live_activity_job(
+      p_event_id, v_schedule.id, 'start', v_schedule.start_time
+    );
+
+    v_end_at := coalesce(v_schedule.end_time, v_schedule.start_time);
+    PERFORM public._schedule_event_live_activity_job(
+      p_event_id, v_schedule.id, 'end', v_end_at
+    );
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sync_event_live_activity_jobs(uuid) IS
+  'Plant Einmal-pg_cron-Jobs für Event-Live-Activities (nur type=event).';
+
+CREATE OR REPLACE FUNCTION public._event_is_type_event(p_type text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT lower(trim(coalesce(p_type, ''))) = 'event';
+$$;
+
+CREATE OR REPLACE FUNCTION public._invoke_schedule_live_activity_change(
+  p_body jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, vault
+AS $$
+DECLARE
+  v_secret text;
+BEGIN
+  SELECT decrypted_secret INTO v_secret
+  FROM vault.decrypted_secrets
+  WHERE name = 'schedule_live_activity_cron_secret'
+  LIMIT 1;
+
+  IF v_secret IS NULL OR v_secret = '' THEN
+    RETURN;
+  END IF;
+
+  PERFORM net.http_post(
+    url := 'https://chrbvfaknykaycwumuba.supabase.co/functions/v1/schedule-live-activity',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', v_secret
+    ),
+    body := p_body
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.trigger_schedule_live_activity_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  target_event_id uuid;
+  request_body jsonb;
+  parent_type text;
+  should_sync boolean := false;
+  should_notify_change boolean := false;
+BEGIN
+  IF TG_TABLE_NAME = 'calendar_events' THEN
+    IF TG_OP = 'INSERT' THEN
+      IF NOT public._event_is_type_event(NEW.type) THEN
+        RETURN NEW;
+      END IF;
+      PERFORM public.sync_event_live_activity_jobs(NEW.id);
+      RETURN NEW;
+    END IF;
+
+    IF TG_OP = 'UPDATE' THEN
+      IF (OLD.event_name, OLD.start_time, OLD.end_time, OLD.location, OLD.type,
+          OLD.choir, OLD.voices, OLD.schooltrack, OLD.class, OLD.series_id,
+          OLD.recurrence_id)
+         IS NOT DISTINCT FROM
+         (NEW.event_name, NEW.start_time, NEW.end_time, NEW.location, NEW.type,
+          NEW.choir, NEW.voices, NEW.schooltrack, NEW.class, NEW.series_id,
+          NEW.recurrence_id) THEN
+        RETURN NEW;
+      END IF;
+
+      IF public._event_is_type_event(OLD.type)
+         OR public._event_is_type_event(NEW.type) THEN
+        should_sync := true;
+      END IF;
+
+      IF public._event_is_type_event(NEW.type) THEN
+        should_notify_change := true;
+        target_event_id := NEW.id;
+        request_body := jsonb_build_object(
+          'mode', 'change',
+          'event_id', target_event_id,
+          'op', TG_OP,
+          'source', 'calendar_events'
+        );
+      ELSIF public._event_is_type_event(OLD.type) THEN
+        should_notify_change := true;
+        target_event_id := OLD.id;
+        request_body := jsonb_build_object(
+          'mode', 'change',
+          'event_id', target_event_id,
+          'op', TG_OP,
+          'source', 'calendar_events',
+          'event_snapshot', jsonb_build_object(
+            'id', OLD.id,
+            'event_name', OLD.event_name,
+            'start_time', OLD.start_time,
+            'end_time', OLD.end_time,
+            'location', OLD.location,
+            'choir', OLD.choir,
+            'voices', OLD.voices,
+            'type', OLD.type
+          )
+        );
+      END IF;
+
+      IF should_sync THEN
+        PERFORM public.sync_event_live_activity_jobs(NEW.id);
+        IF public._event_is_type_event(OLD.type)
+           AND NOT public._event_is_type_event(NEW.type) THEN
+          PERFORM public._clear_event_live_activity_jobs(OLD.id);
+        END IF;
+      END IF;
+
+      IF should_notify_change THEN
+        PERFORM public._invoke_schedule_live_activity_change(request_body);
+      END IF;
+
+      RETURN NEW;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+      IF NOT public._event_is_type_event(OLD.type) THEN
+        RETURN OLD;
+      END IF;
+
+      PERFORM public._clear_event_live_activity_jobs(OLD.id);
+      target_event_id := OLD.id;
+      request_body := jsonb_build_object(
+        'mode', 'change',
+        'event_id', target_event_id,
+        'op', TG_OP,
+        'source', 'calendar_events',
+        'event_snapshot', jsonb_build_object(
+          'id', OLD.id,
+          'event_name', OLD.event_name,
+          'start_time', OLD.start_time,
+          'end_time', OLD.end_time,
+          'location', OLD.location,
+          'choir', OLD.choir,
+          'voices', OLD.voices,
+          'type', OLD.type
+        )
+      );
+      PERFORM public._invoke_schedule_live_activity_change(request_body);
+      RETURN OLD;
+    END IF;
+
+  ELSIF TG_TABLE_NAME = 'event_schedules' THEN
+    IF TG_OP = 'UPDATE' THEN
+      IF (OLD.event_id, OLD.title, OLD.description, OLD.start_time, OLD.end_time,
+          OLD.location, OLD.choir, OLD.voices)
+         IS NOT DISTINCT FROM
+         (NEW.event_id, NEW.title, NEW.description, NEW.start_time, NEW.end_time,
+          NEW.location, NEW.choir, NEW.voices) THEN
+        RETURN NEW;
+      END IF;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+      target_event_id := OLD.event_id;
+    ELSE
+      target_event_id := NEW.event_id;
+    END IF;
+
+    SELECT type INTO parent_type
+    FROM public.calendar_events
+    WHERE id = target_event_id;
+
+    IF NOT FOUND OR NOT public._event_is_type_event(parent_type) THEN
+      RETURN COALESCE(NEW, OLD);
+    END IF;
+
+    PERFORM public.sync_event_live_activity_jobs(target_event_id);
+
+    request_body := jsonb_build_object(
+      'mode', 'change',
+      'event_id', target_event_id,
+      'op', TG_OP,
+      'source', 'event_schedules'
+    );
+    PERFORM public._invoke_schedule_live_activity_change(request_body);
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+COMMENT ON FUNCTION public.trigger_schedule_live_activity_change() IS
+  'Sync + sofortiger Change-Handler für Event-Live-Activities (nur type=event).';
+
+DROP TRIGGER IF EXISTS schedule_live_activity_calendar_events_change
+  ON public.calendar_events;
+CREATE TRIGGER schedule_live_activity_calendar_events_change
+  AFTER INSERT OR UPDATE OR DELETE ON public.calendar_events
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trigger_schedule_live_activity_change();
+
+DROP TRIGGER IF EXISTS schedule_live_activity_event_schedules_change
+  ON public.event_schedules;
+CREATE TRIGGER schedule_live_activity_event_schedules_change
+  AFTER INSERT OR UPDATE OR DELETE ON public.event_schedules
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trigger_schedule_live_activity_change();
+
+-- Bestehende zukünftige Events type=event nachplanen.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT id
+    FROM public.calendar_events
+    WHERE lower(trim(coalesce(type, ''))) = 'event'
+      AND end_time > now()
+  LOOP
+    PERFORM public.sync_event_live_activity_jobs(r.id);
+  END LOOP;
+END $$;

--- a/test/features/calendar/live_activity/schedule_live_activity_logic_test.dart
+++ b/test/features/calendar/live_activity/schedule_live_activity_logic_test.dart
@@ -2,6 +2,7 @@ import 'package:chronoapp/features/calendar/domain/filter/calendar_filters_state
 import 'package:chronoapp/features/calendar/domain/filter/event_schedule_filter.dart';
 import 'package:chronoapp/features/calendar/domain/models/event_schedule.dart';
 import 'package:chronoapp/features/calendar/live_activity/data/schedule_segment_timer_scheduler.dart';
+import 'package:chronoapp/features/calendar/live_activity/domain/schedule_live_activity_event.dart';
 import 'package:chronoapp/features/calendar/live_activity/domain/schedule_live_activity_resolver.dart';
 import 'package:chronoapp/features/calendar/live_activity/domain/schedule_live_activity_snapshot.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -103,6 +104,50 @@ void main() {
         start.millisecondsSinceEpoch,
       );
       expect(snapshot.segmentEndMs, end.millisecondsSinceEpoch);
+    });
+
+    test('resolveFromEvent für Termin ohne Ablaufplan', () {
+      final start = DateTime(2026, 6, 24, 18, 0);
+      final end = DateTime(2026, 6, 24, 20, 0);
+      final now = DateTime(2026, 6, 24, 18, 30);
+
+      final snapshot = ScheduleLiveActivityResolver.resolveFromEvent(
+        event: ScheduleLiveActivityEvent(
+          id: 'event-only',
+          eventName: 'Sommerfest',
+          location: 'Aula',
+          startTime: start,
+          endTime: end,
+        ),
+        filters: filters,
+        now: now,
+      );
+
+      expect(snapshot, isNotNull);
+      expect(snapshot!.currentTitle, 'Sommerfest');
+      expect(snapshot.currentSubtitle, 'Aula');
+      expect(snapshot.hasNext, isFalse);
+      expect(snapshot.segmentStartMs, start.millisecondsSinceEpoch);
+      expect(snapshot.segmentEndMs, end.millisecondsSinceEpoch);
+    });
+
+    test('resolveFromEvent vor Terminstart liefert null', () {
+      final start = DateTime(2026, 6, 24, 18, 0);
+      final end = DateTime(2026, 6, 24, 20, 0);
+      final now = DateTime(2026, 6, 24, 17, 30);
+
+      final snapshot = ScheduleLiveActivityResolver.resolveFromEvent(
+        event: ScheduleLiveActivityEvent(
+          id: 'event-only',
+          eventName: 'Sommerfest',
+          startTime: start,
+          endTime: end,
+        ),
+        filters: filters,
+        now: now,
+      );
+
+      expect(snapshot, isNull);
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Der minütliche pg_cron-Job `schedule-live-activity` wird entfernt. Stattdessen plant Postgres bei Änderungen an `calendar_events` (nur `type = 'event'`) und deren `event_schedules` gezielte Einmal-Jobs, die die Edge Function exakt zu Start-/Endzeitpunkten aufrufen.

## Änderungen

### Backend / Postgres
- **Cron entfernt:** Migration `20260704120000` unschedult `schedule-live-activity`
- **Job-Tabelle:** `event_live_activity_jobs` + `sync_event_live_activity_jobs()` plant Einmal-pg_cron-Jobs pro Start/Ende
- **Trigger:** INSERT auf `calendar_events`, Type-Filter `event`, Job-Sync + sofortiger Change-Handler
- **Backfill:** Bestehende zukünftige Events werden nachgeplant

### Edge Function `schedule-live-activity`
- `handleCronTick` entfernt; neuer Modus `dispatch` für geplante Sends
- Live Activities auch für Termine **ohne Ablaufplan** (Snapshot aus Termin-Daten)
- Geräte werden nach Chor/Stimmen-Zielgruppe gefiltert (`loadDevicesForEvent`)

### Flutter
- DataSource, Resolver und Coordinator unterstützen Event-Termine ohne Ablaufplan
- Lokale Notifications/Timer für Termin-Start/-Ende

### Docs & Tests
- `backend/PUSH_NOTIFICATIONS.md` und Setup-SQL aktualisiert
- Unit-Tests für `resolveFromEvent`

## Deploy-Hinweise

```bash
supabase db push
supabase functions deploy schedule-live-activity --no-verify-jwt
```

Vault-Secret `schedule_live_activity_cron_secret` muss weiterhin gesetzt sein (siehe `backend/SCHEDULE_LIVE_ACTIVITY_CRON_SETUP.sql`).

## Test

- `flutter test test/features/calendar/live_activity/schedule_live_activity_logic_test.dart` — 10 Tests bestanden

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f26e0-f6f7-7bf3-9e92-4826e7b89e01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f26e0-f6f7-7bf3-9e92-4826e7b89e01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

