### PR TITLE
Live Activity: Bulk-Dispatch, Logging und iOS ContentState-Fix

### DIFF
--- a/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
+++ b/ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift
@@ -14,11 +14,72 @@ struct ChronoWidgetExtensionBundle: WidgetBundle {
 
 struct LiveActivitiesAppAttributes: ActivityAttributes, Identifiable {
   public typealias LiveDeliveryData = ContentState
-  public struct ContentState: Codable, Hashable {}
+
+  /// Vollstaendiger Payload fuer Remote Push-to-Start/-Update (APNS `content-state`).
+  /// Lokale Starts via Flutter schreiben weiterhin in UserDefaults; fehlende Felder
+  /// werden dort als Fallback gelesen.
+  public struct ContentState: Codable, Hashable {
+    var appGroupId: String?
+    var kind: String?
+    var dayDate: String?
+    var segmentsJson: String?
+    var activityStartMs: Double?
+    var dayEndMs: Double?
+    var remainingLessons: Int?
+    var currentIndex: Int?
+    var currentTitle: String?
+    var currentSubtitle: String?
+    var hasNext: Bool?
+    var nextTitle: String?
+    var nextSubtitle: String?
+    var segmentStartMs: Double?
+    var segmentEndMs: Double?
+    var accentColor: String?
+    var isMeal: Bool?
+    var imageUrl: String?
+    var eventId: String?
+    var isPreStart: Bool?
+  }
+
   var id = UUID()
 }
 
 let sharedDefault = UserDefaults(suiteName: "group.com.domspatzen.chronoapp")!
+
+/// Liest Anzeigefelder primaer aus [ActivityViewContext.state] (Remote-Push),
+/// mit UserDefaults als Fallback (lokaler App-Start via live_activities-Plugin).
+private struct LiveActivityDataSource {
+  let state: LiveActivitiesAppAttributes.ContentState
+  let prefixedKey: (String) -> String
+
+  init(context: ActivityViewContext<LiveActivitiesAppAttributes>) {
+    state = context.state
+    prefixedKey = context.attributes.prefixedKey
+  }
+
+  func string(_ name: String, stateValue: String?) -> String {
+    if let value = stateValue { return value }
+    return sharedDefault.string(forKey: prefixedKey(name)) ?? ""
+  }
+
+  func double(_ name: String, stateValue: Double?) -> Double {
+    if let value = stateValue { return value }
+    return sharedDefault.double(forKey: prefixedKey(name))
+  }
+
+  func int(_ name: String, stateValue: Int?) -> Int {
+    if let value = stateValue { return value }
+    return Int(sharedDefault.integer(forKey: prefixedKey(name)))
+  }
+
+  func bool(_ name: String, stateValue: Bool?) -> Bool? {
+    if let value = stateValue { return value }
+    if sharedDefault.object(forKey: prefixedKey(name)) != nil {
+      return sharedDefault.bool(forKey: prefixedKey(name))
+    }
+    return nil
+  }
+}
 
 private struct ScheduleLiveData {
   let eventId: String
@@ -31,21 +92,19 @@ private struct ScheduleLiveData {
   let segmentEnd: Date
 
   init(context: ActivityViewContext<LiveActivitiesAppAttributes>) {
-    func key(_ name: String) -> String {
-      context.attributes.prefixedKey(name)
-    }
-    currentTitle = sharedDefault.string(forKey: key("currentTitle")) ?? ""
-    currentSubtitle = sharedDefault.string(forKey: key("currentSubtitle")) ?? ""
-    eventId = sharedDefault.string(forKey: key("eventId")) ?? ""
-    nextTitle = sharedDefault.string(forKey: key("nextTitle")) ?? ""
-    nextSubtitle = sharedDefault.string(forKey: key("nextSubtitle")) ?? ""
-    if sharedDefault.object(forKey: key("hasNext")) != nil {
-      hasNext = sharedDefault.bool(forKey: key("hasNext"))
+    let source = LiveActivityDataSource(context: context)
+    currentTitle = source.string("currentTitle", stateValue: source.state.currentTitle)
+    currentSubtitle = source.string("currentSubtitle", stateValue: source.state.currentSubtitle)
+    eventId = source.string("eventId", stateValue: source.state.eventId)
+    nextTitle = source.string("nextTitle", stateValue: source.state.nextTitle)
+    nextSubtitle = source.string("nextSubtitle", stateValue: source.state.nextSubtitle)
+    if let resolvedHasNext = source.bool("hasNext", stateValue: source.state.hasNext) {
+      hasNext = resolvedHasNext
     } else {
       hasNext = !nextTitle.isEmpty
     }
-    let startMs = sharedDefault.double(forKey: key("segmentStartMs"))
-    let endMs = sharedDefault.double(forKey: key("segmentEndMs"))
+    let startMs = source.double("segmentStartMs", stateValue: source.state.segmentStartMs)
+    let endMs = source.double("segmentEndMs", stateValue: source.state.segmentEndMs)
     segmentStart = Date(timeIntervalSince1970: startMs / 1000)
     segmentEnd = Date(timeIntervalSince1970: endMs / 1000)
   }
@@ -83,6 +142,9 @@ private func timetableDeepLink(for dayDate: String) -> URL? {
 }
 
 private func readKind(context: ActivityViewContext<LiveActivitiesAppAttributes>) -> String {
+  if let kind = context.state.kind, !kind.isEmpty {
+    return kind
+  }
   let key = context.attributes.prefixedKey("kind")
   return sharedDefault.string(forKey: key) ?? "schedule"
 }
@@ -177,31 +239,36 @@ private struct TimetableLiveData {
   let remainingLessons: Int
 
   init(context: ActivityViewContext<LiveActivitiesAppAttributes>) {
-    func key(_ name: String) -> String {
-      context.attributes.prefixedKey(name)
-    }
-    dayDate = sharedDefault.string(forKey: key("dayDate")) ?? ""
+    let source = LiveActivityDataSource(context: context)
+    dayDate = source.string("dayDate", stateValue: source.state.dayDate)
 
-    var resolvedCurrentTitle = sharedDefault.string(forKey: key("currentTitle")) ?? ""
-    var resolvedCurrentSubtitle = sharedDefault.string(forKey: key("currentSubtitle")) ?? ""
-    var resolvedNextTitle = sharedDefault.string(forKey: key("nextTitle")) ?? ""
-    var resolvedNextSubtitle = sharedDefault.string(forKey: key("nextSubtitle")) ?? ""
+    var resolvedCurrentTitle = source.string("currentTitle", stateValue: source.state.currentTitle)
+    var resolvedCurrentSubtitle = source.string(
+      "currentSubtitle", stateValue: source.state.currentSubtitle)
+    var resolvedNextTitle = source.string("nextTitle", stateValue: source.state.nextTitle)
+    var resolvedNextSubtitle = source.string("nextSubtitle", stateValue: source.state.nextSubtitle)
     var resolvedHasNext: Bool
-    if sharedDefault.object(forKey: key("hasNext")) != nil {
-      resolvedHasNext = sharedDefault.bool(forKey: key("hasNext"))
+    if let hasNextValue = source.bool("hasNext", stateValue: source.state.hasNext) {
+      resolvedHasNext = hasNextValue
     } else {
       resolvedHasNext = !resolvedNextTitle.isEmpty
     }
-    var resolvedAccentHex = sharedDefault.string(forKey: key("accentColor")) ?? "#124E30"
-    var resolvedIsMeal = sharedDefault.bool(forKey: key("isMeal"))
-    var resolvedRemainingLessons = Int(sharedDefault.integer(forKey: key("remainingLessons")))
+    var resolvedAccentHex = source.string("accentColor", stateValue: source.state.accentColor)
+    if resolvedAccentHex.isEmpty {
+      resolvedAccentHex = "#124E30"
+    }
+    var resolvedIsMeal = source.bool("isMeal", stateValue: source.state.isMeal) ?? false
+    var resolvedRemainingLessons = source.int(
+      "remainingLessons", stateValue: source.state.remainingLessons)
 
-    var startMs = sharedDefault.double(forKey: key("segmentStartMs"))
-    var endMs = sharedDefault.double(forKey: key("segmentEndMs"))
+    var startMs = source.double("segmentStartMs", stateValue: source.state.segmentStartMs)
+    var endMs = source.double("segmentEndMs", stateValue: source.state.segmentEndMs)
 
     if endMs <= startMs {
-      let segments = parseTimetableSegments(sharedDefault.string(forKey: key("segmentsJson")))
-      let activityStartMs = sharedDefault.double(forKey: key("activityStartMs"))
+      let segmentsJson = source.string("segmentsJson", stateValue: source.state.segmentsJson)
+      let segments = parseTimetableSegments(segmentsJson.isEmpty ? nil : segmentsJson)
+      let activityStartMs = source.double(
+        "activityStartMs", stateValue: source.state.activityStartMs)
       let nowMs = Date().timeIntervalSince1970 * 1000
       if let resolved = resolveTimetableSegment(
         segments: segments, activityStartMs: activityStartMs, nowMs: nowMs)
@@ -238,8 +305,8 @@ private struct TimetableLiveData {
     remainingLessons = resolvedRemainingLessons
     segmentStart = Date(timeIntervalSince1970: startMs / 1000)
     segmentEnd = Date(timeIntervalSince1970: endMs / 1000)
-    imageUrl = sharedDefault.string(forKey: key("imageUrl"))
-    mealImagePath = sharedDefault.string(forKey: key("mealImage"))
+    imageUrl = source.string("imageUrl", stateValue: source.state.imageUrl)
+    mealImagePath = sharedDefault.string(forKey: source.prefixedKey("mealImage"))
   }
 
   var compactLeadingLabel: String {

--- a/supabase/functions/_shared/live_activity/devices.ts
+++ b/supabase/functions/_shared/live_activity/devices.ts
@@ -84,15 +84,63 @@ export async function loadTimetableDevices(
   supabase: ReturnType<typeof createClient>,
   userId: string,
 ): Promise<DeviceRow[]> {
-  // Siehe loadEventDevices: nur fcm_token ist zwingend erforderlich.
-  const { data, error } = await supabase
+  return loadTimetableDevicesBulk(supabase, { userId });
+}
+
+export type TimetableDeviceFilter = {
+  userId?: string;
+  className?: string | null;
+  schooltrack?: string | null;
+};
+
+/** Lädt Geräte für Stundenplan-Dispatch in einem Query (ein User oder ganze Kohorte). */
+export async function loadTimetableDevicesBulk(
+  supabase: ReturnType<typeof createClient>,
+  filter: TimetableDeviceFilter,
+): Promise<DeviceRow[]> {
+  let query = supabase
     .from("profile_push_devices")
     .select(
       "id, user_id, device_id, fcm_token, platform, schedule_filter, push_to_start_token, live_activity_push_token, profiles!inner(id, choir, voice, class_name, schooltrack)",
     )
-    .eq("user_id", userId)
     .not("fcm_token", "is", null);
 
+  if (filter.userId) {
+    query = query.eq("user_id", filter.userId);
+  }
+
+  const { data, error } = await query;
   if (error) throw new Error(error.message);
-  return (data ?? []) as DeviceRow[];
+
+  let devices = (data ?? []) as DeviceRow[];
+
+  if (filter.className !== undefined || filter.schooltrack !== undefined) {
+    const wantClass = normalizeText(filter.className ?? null);
+    const wantTrack = normalizeText(filter.schooltrack ?? null);
+
+    devices = devices.filter((device) => {
+      const profile = asProfile(device.profiles);
+      if (!profile) return false;
+      const profileClass = normalizeText(profile.class_name ?? null);
+      const profileTrack = normalizeText(profile.schooltrack ?? null);
+      if (wantClass !== profileClass) return false;
+      if (wantTrack !== profileTrack) return false;
+      return true;
+    });
+  }
+
+  return devices;
+}
+
+/** Gruppiert Geräte nach user_id – für Bulk-Dispatch mit personalisiertem Snapshot. */
+export function groupDevicesByUser(
+  devices: DeviceRow[],
+): Map<string, DeviceRow[]> {
+  const grouped = new Map<string, DeviceRow[]>();
+  for (const device of devices) {
+    const list = grouped.get(device.user_id) ?? [];
+    list.push(device);
+    grouped.set(device.user_id, list);
+  }
+  return grouped;
 }

--- a/supabase/functions/_shared/live_activity/dispatch_log.ts
+++ b/supabase/functions/_shared/live_activity/dispatch_log.ts
@@ -1,0 +1,96 @@
+import type { LiveActivityFcmEvent } from "../fcm_v1.ts";
+import type { LiveActivityKind } from "./types.ts";
+
+export type SkipReason =
+  | "already_dispatched"
+  | "no_fcm_token"
+  | "missing_ios_start_token"
+  | "missing_ios_update_token"
+  | "no_profile"
+  | "no_snapshot"
+  | "fcm_failed";
+
+export type DeviceDispatchDetail = {
+  device_id: string;
+  user_id: string;
+  platform: string;
+  result: "sent" | "skipped" | "failed";
+  skip_reason?: SkipReason;
+  error_code?: string;
+};
+
+export type DispatchSummary = {
+  mode: string;
+  kind: LiveActivityKind;
+  reference_id: string;
+  action?: LiveActivityFcmEvent;
+  user_id?: string | null;
+  class_name?: string | null;
+  schooltrack?: string | null;
+  job_id?: string | null;
+  users_processed: number;
+  devices_total: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  skip_reasons: Partial<Record<SkipReason, number>>;
+  duration_ms: number;
+  devices?: DeviceDispatchDetail[];
+};
+
+const MAX_DEVICE_DETAILS = 20;
+
+export function createDispatchSummary(
+  base: Omit<
+    DispatchSummary,
+    "sent" | "skipped" | "failed" | "skip_reasons" | "duration_ms" | "devices"
+  >,
+  startedAt: number,
+  details: DeviceDispatchDetail[],
+): DispatchSummary {
+  let sent = 0;
+  let skipped = 0;
+  let failed = 0;
+  const skip_reasons: Partial<Record<SkipReason, number>> = {};
+
+  for (const detail of details) {
+    if (detail.result === "sent") sent++;
+    else if (detail.result === "failed") failed++;
+    else skipped++;
+
+    if (detail.skip_reason) {
+      skip_reasons[detail.skip_reason] = (skip_reasons[detail.skip_reason] ?? 0) + 1;
+    }
+  }
+
+  const summary: DispatchSummary = {
+    ...base,
+    sent,
+    skipped,
+    failed,
+    skip_reasons,
+    duration_ms: Date.now() - startedAt,
+  };
+
+  if (details.length > 0 && details.length <= MAX_DEVICE_DETAILS) {
+    summary.devices = details;
+  }
+
+  return summary;
+}
+
+/** Strukturiertes Log für Supabase Edge Function Logs (console). */
+export function logDispatchSummary(summary: DispatchSummary): void {
+  const line = JSON.stringify({
+    tag: "live_activity_dispatch",
+    ...summary,
+  });
+  console.log(line);
+
+  if (summary.failed > 0) {
+    console.warn(
+      `live_activity_dispatch: ${summary.failed} failed, ${summary.sent} sent, ${summary.skipped} skipped` +
+        ` (${summary.kind}/${summary.action ?? "?"} ${summary.reference_id})`,
+    );
+  }
+}

--- a/supabase/functions/_shared/live_activity/fcm_dispatch.ts
+++ b/supabase/functions/_shared/live_activity/fcm_dispatch.ts
@@ -5,10 +5,291 @@ import {
   type LiveActivityFcmEvent,
 } from "../fcm_v1.ts";
 import type { FirebaseServiceAccount } from "../fcm_v1.ts";
+import type { DeviceDispatchDetail, SkipReason } from "./dispatch_log.ts";
 import type { DeviceRow, LiveActivityKind } from "./types.ts";
 
 export type SendResult = "sent" | "skipped" | "failed";
 
+export type DispatchTarget = {
+  device: DeviceRow;
+  fcmEvent: LiveActivityFcmEvent;
+  contentState: Record<string, string | number | boolean>;
+  dedupKey: Record<string, string>;
+};
+
+export type BatchDispatchOptions = {
+  kind: LiveActivityKind;
+  referenceId: string;
+  activityType: string;
+  dayDate?: string;
+  dedupTable: "schedule_live_activity_dispatches" | "timetable_live_activity_dispatches";
+  skipDedup?: boolean;
+  concurrency?: number;
+};
+
+const DEFAULT_CONCURRENCY = 12;
+
+function deviceDetail(
+  device: DeviceRow,
+  result: DeviceDispatchDetail["result"],
+  extra?: Partial<DeviceDispatchDetail>,
+): DeviceDispatchDetail {
+  return {
+    device_id: device.device_id,
+    user_id: device.user_id,
+    platform: device.platform,
+    result,
+    ...extra,
+  };
+}
+
+export function evaluateDeviceReadiness(
+  device: DeviceRow,
+  fcmEvent: LiveActivityFcmEvent,
+): SkipReason | null {
+  if (!device.fcm_token?.trim()) return "no_fcm_token";
+
+  if (device.platform === "ios") {
+    const hasPushToStart = !!device.push_to_start_token?.trim();
+    const hasLiveActivityToken = !!device.live_activity_push_token?.trim();
+    if (fcmEvent === "start" && !hasPushToStart) return "missing_ios_start_token";
+    if (
+      (fcmEvent === "update" || fcmEvent === "end") &&
+      !hasLiveActivityToken
+    ) {
+      return "missing_ios_update_token";
+    }
+  }
+
+  return null;
+}
+
+export async function loadDispatchedDeviceKeys(
+  supabase: ReturnType<typeof createClient>,
+  table: BatchDispatchOptions["dedupTable"],
+  keys: Record<string, string>[],
+  action: LiveActivityFcmEvent,
+): Promise<Set<string>> {
+  if (keys.length === 0) return new Set();
+
+  const dispatched = new Set<string>();
+
+  if (table === "schedule_live_activity_dispatches") {
+    const scheduleIds = [...new Set(keys.map((k) => k.schedule_id))];
+    const userIds = [...new Set(keys.map((k) => k.user_id))];
+
+    const { data, error } = await supabase
+      .from(table)
+      .select("schedule_id, user_id, device_id")
+      .eq("action", action)
+      .in("schedule_id", scheduleIds)
+      .in("user_id", userIds);
+
+    if (error) throw new Error(error.message);
+
+    for (const row of data ?? []) {
+      dispatched.add(`${row.schedule_id}:${row.user_id}:${row.device_id}`);
+    }
+    return dispatched;
+  }
+
+  const dayDates = [...new Set(keys.map((k) => k.day_date))];
+  const userIds = [...new Set(keys.map((k) => k.user_id))];
+
+  const { data, error } = await supabase
+    .from(table)
+    .select("day_date, user_id, device_id")
+    .eq("action", action)
+    .in("day_date", dayDates)
+    .in("user_id", userIds);
+
+  if (error) throw new Error(error.message);
+
+  for (const row of data ?? []) {
+    dispatched.add(`${row.day_date}:${row.user_id}:${row.device_id}`);
+  }
+
+  return dispatched;
+}
+
+function dedupLookupKey(
+  table: BatchDispatchOptions["dedupTable"],
+  dedupKey: Record<string, string>,
+): string {
+  if (table === "schedule_live_activity_dispatches") {
+    return `${dedupKey.schedule_id}:${dedupKey.user_id}:${dedupKey.device_id}`;
+  }
+  return `${dedupKey.day_date}:${dedupKey.user_id}:${dedupKey.device_id}`;
+}
+
+async function markDispatchedBatch(
+  supabase: ReturnType<typeof createClient>,
+  table: BatchDispatchOptions["dedupTable"],
+  rows: Array<{ key: Record<string, string>; action: LiveActivityFcmEvent }>,
+): Promise<void> {
+  if (rows.length === 0) return;
+
+  const sentAt = new Date().toISOString();
+
+  if (table === "schedule_live_activity_dispatches") {
+    await supabase.from(table).upsert(
+      rows.map(({ key, action }) => ({
+        schedule_id: key.schedule_id,
+        user_id: key.user_id,
+        device_id: key.device_id,
+        action,
+        sent_at: sentAt,
+      })),
+      { onConflict: "schedule_id,user_id,device_id,action" },
+    );
+    return;
+  }
+
+  await supabase.from(table).upsert(
+    rows.map(({ key, action }) => ({
+      day_date: key.day_date,
+      user_id: key.user_id,
+      device_id: key.device_id,
+      action,
+      sent_at: sentAt,
+    })),
+    { onConflict: "day_date,user_id,device_id,action" },
+  );
+}
+
+async function deleteUnregisteredDevices(
+  supabase: ReturnType<typeof createClient>,
+  deviceIds: string[],
+): Promise<void> {
+  if (deviceIds.length === 0) return;
+  await supabase.from("profile_push_devices").delete().in("id", deviceIds);
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+export async function sendLiveActivityBatch(
+  supabase: ReturnType<typeof createClient>,
+  serviceAccount: FirebaseServiceAccount,
+  targets: DispatchTarget[],
+  options: BatchDispatchOptions,
+): Promise<DeviceDispatchDetail[]> {
+  if (targets.length === 0) return [];
+
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  const details: DeviceDispatchDetail[] = [];
+  const pending: DispatchTarget[] = [];
+
+  let dispatchedKeys: Set<string> | null = null;
+  if (!options.skipDedup && targets.length > 0) {
+    dispatchedKeys = await loadDispatchedDeviceKeys(
+      supabase,
+      options.dedupTable,
+      targets.map((t) => t.dedupKey),
+      targets[0].fcmEvent,
+    );
+  }
+
+  for (const target of targets) {
+    const readiness = evaluateDeviceReadiness(target.device, target.fcmEvent);
+    if (readiness) {
+      details.push(deviceDetail(target.device, "skipped", { skip_reason: readiness }));
+      continue;
+    }
+
+    if (
+      dispatchedKeys &&
+      dispatchedKeys.has(dedupLookupKey(options.dedupTable, target.dedupKey))
+    ) {
+      details.push(
+        deviceDetail(target.device, "skipped", { skip_reason: "already_dispatched" }),
+      );
+      continue;
+    }
+
+    pending.push(target);
+  }
+
+  const activityIdPrefix = options.kind === "timetable" ? "timetable_" : "event_";
+
+  const sendResults = await mapWithConcurrency(pending, concurrency, async (target) => {
+    const { device, fcmEvent, contentState } = target;
+    const activityId = `${activityIdPrefix}${options.referenceId}`;
+
+    const result = await sendLiveActivityFcm(serviceAccount, {
+      token: device.fcm_token.trim(),
+      platform: device.platform,
+      event: fcmEvent,
+      activityId,
+      contentState,
+      eventId: options.referenceId,
+      dayDate: options.dayDate,
+      activityType: options.activityType,
+      liveActivityPushToken: device.live_activity_push_token,
+      pushToStartToken: device.push_to_start_token,
+    });
+
+    return { target, result };
+  });
+
+  const toMark: Array<{ key: Record<string, string>; action: LiveActivityFcmEvent }> = [];
+  const toDelete: string[] = [];
+
+  for (const { target, result } of sendResults) {
+    if (result.ok) {
+      if (!options.skipDedup) {
+        toMark.push({ key: target.dedupKey, action: target.fcmEvent });
+      }
+      details.push(deviceDetail(target.device, "sent"));
+      continue;
+    }
+
+    console.error(
+      `LiveActivity FCM failed ${target.device.id}: ${result.errorCode} ${result.errorMessage}`,
+    );
+
+    if (isUnregisteredTokenError(result.errorCode)) {
+      toDelete.push(target.device.id);
+    }
+
+    details.push(
+      deviceDetail(target.device, "failed", {
+        skip_reason: "fcm_failed",
+        error_code: result.errorCode,
+      }),
+    );
+  }
+
+  await Promise.all([
+    markDispatchedBatch(supabase, options.dedupTable, toMark),
+    deleteUnregisteredDevices(supabase, toDelete),
+  ]);
+
+  return details;
+}
+
+/** Einzelversand – nutzt dieselbe Logik wie der Batch-Pfad. */
 export async function sendLiveActivityToDevice(
   supabase: ReturnType<typeof createClient>,
   serviceAccount: FirebaseServiceAccount,
@@ -25,128 +306,25 @@ export async function sendLiveActivityToDevice(
     skipDedup?: boolean;
   },
 ): Promise<SendResult> {
-  if (!options.skipDedup) {
-    const already = await wasDispatched(
-      supabase,
-      options.dedupTable,
-      options.dedupKey,
-      options.fcmEvent,
-    );
-    if (already) return "skipped";
-  }
-
-  const token = device.fcm_token?.trim();
-  if (!token) return "skipped";
-
-  // iOS braucht fuer Live-Activity-Pushes zwingend den passenden Token im
-  // apns.live_activity_token-Feld (push_to_start_token fuer "start",
-  // live_activity_push_token fuer "update"/"end"). Ohne ihn lehnt APNs den
-  // Push mit INVALID_ARGUMENT ab - das sah lange wie ein "totes fcm_token"
-  // aus und fuehrte zum faelschlichen Loeschen frisch registrierter Geraete
-  // (siehe isUnregisteredTokenError). Deshalb hier vorher pruefen und ohne
-  // Sendeversuch ueberspringen, statt einen garantiert scheiternden Push
-  // abzuschicken.
-  if (device.platform === "ios") {
-    const hasPushToStart = !!device.push_to_start_token?.trim();
-    const hasLiveActivityToken = !!device.live_activity_push_token?.trim();
-    if (options.fcmEvent === "start" && !hasPushToStart) return "skipped";
-    if (
-      (options.fcmEvent === "update" || options.fcmEvent === "end") &&
-      !hasLiveActivityToken
-    ) {
-      return "skipped";
-    }
-  }
-
-  const activityId = options.kind === "timetable"
-    ? `timetable_${options.referenceId}`
-    : `event_${options.referenceId}`;
-
-  const result = await sendLiveActivityFcm(serviceAccount, {
-    token,
-    platform: device.platform,
-    event: options.fcmEvent,
-    activityId,
-    contentState: options.contentState,
-    eventId: options.referenceId,
-    dayDate: options.dayDate,
-    activityType: options.activityType,
-    liveActivityPushToken: device.live_activity_push_token,
-    pushToStartToken: device.push_to_start_token,
-  });
-
-  if (result.ok) {
-    if (!options.skipDedup) {
-      await markDispatched(
-        supabase,
-        options.dedupTable,
-        options.dedupKey,
-        options.fcmEvent,
-      );
-    }
-    return "sent";
-  }
-
-  console.error(
-    `LiveActivity FCM failed ${device.id}: ${result.errorCode} ${result.errorMessage}`,
+  const [detail] = await sendLiveActivityBatch(
+    supabase,
+    serviceAccount,
+    [{
+      device,
+      fcmEvent: options.fcmEvent,
+      contentState: options.contentState,
+      dedupKey: options.dedupKey,
+    }],
+    {
+      kind: options.kind,
+      referenceId: options.referenceId,
+      activityType: options.activityType,
+      dayDate: options.dayDate,
+      dedupTable: options.dedupTable,
+      skipDedup: options.skipDedup,
+      concurrency: 1,
+    },
   );
-  if (isUnregisteredTokenError(result.errorCode)) {
-    await supabase.from("profile_push_devices").delete().eq("id", device.id);
-  }
-  return "failed";
-}
 
-async function wasDispatched(
-  supabase: ReturnType<typeof createClient>,
-  table: string,
-  key: Record<string, string>,
-  action: LiveActivityFcmEvent,
-): Promise<boolean> {
-  if (table === "schedule_live_activity_dispatches") {
-    const { data } = await supabase
-      .from(table)
-      .select("id")
-      .eq("schedule_id", key.schedule_id)
-      .eq("user_id", key.user_id)
-      .eq("device_id", key.device_id)
-      .eq("action", action)
-      .maybeSingle();
-    return data != null;
-  }
-
-  const { data } = await supabase
-    .from(table)
-    .select("id")
-    .eq("day_date", key.day_date)
-    .eq("user_id", key.user_id)
-    .eq("device_id", key.device_id)
-    .eq("action", action)
-    .maybeSingle();
-  return data != null;
-}
-
-async function markDispatched(
-  supabase: ReturnType<typeof createClient>,
-  table: string,
-  key: Record<string, string>,
-  action: LiveActivityFcmEvent,
-): Promise<void> {
-  if (table === "schedule_live_activity_dispatches") {
-    await supabase.from(table).upsert({
-      schedule_id: key.schedule_id,
-      user_id: key.user_id,
-      device_id: key.device_id,
-      action,
-      sent_at: new Date().toISOString(),
-    }, { onConflict: "schedule_id,user_id,device_id,action" });
-    return;
-  }
-
-  await supabase.from(table).upsert({
-    day_date: key.day_date,
-    user_id: key.user_id,
-    device_id: key.device_id,
-    action,
-    sent_at: new Date().toISOString(),
-  }, { onConflict: "day_date,user_id,device_id,action" });
+  return detail?.result ?? "skipped";
 }

--- a/supabase/functions/_shared/live_activity/types.ts
+++ b/supabase/functions/_shared/live_activity/types.ts
@@ -8,6 +8,8 @@ export type RequestBody = {
   reference_id?: string;
   event_id?: string;
   user_id?: string;
+  class_name?: string | null;
+  schooltrack?: string | null;
   schedule_id?: string | null;
   action?: LiveActivityFcmEvent;
   job_id?: string;

--- a/supabase/functions/live-activity/index.ts
+++ b/supabase/functions/live-activity/index.ts
@@ -185,6 +185,7 @@ function resolveFcmEvent(
 ): LiveActivityFcmEvent {
   if (requested === "end") return "end";
   if (requested === "update") return "update";
+  if (requested === "start") return "start";
   return resolveSegmentStartEvent(device);
 }
 

--- a/supabase/functions/live-activity/index.ts
+++ b/supabase/functions/live-activity/index.ts
@@ -6,7 +6,23 @@
 import { createClient } from "npm:@supabase/supabase-js@2.49.1";
 import { parseServiceAccountJson } from "../_shared/fcm_v1.ts";
 import type { LiveActivityFcmEvent } from "../_shared/fcm_v1.ts";
-import { asProfile, loadEventDevices, loadTimetableDevices, profileMatchesEvent, resolveSegmentStartEvent } from "../_shared/live_activity/devices.ts";
+import {
+  createDispatchSummary,
+  logDispatchSummary,
+  type DeviceDispatchDetail,
+} from "../_shared/live_activity/dispatch_log.ts";
+import {
+  asProfile,
+  groupDevicesByUser,
+  loadEventDevices,
+  loadTimetableDevicesBulk,
+  profileMatchesEvent,
+  resolveSegmentStartEvent,
+} from "../_shared/live_activity/devices.ts";
+import {
+  sendLiveActivityBatch,
+  type DispatchTarget,
+} from "../_shared/live_activity/fcm_dispatch.ts";
 import {
   buildEventOnlySnapshot,
   buildEventSnapshot,
@@ -17,7 +33,6 @@ import {
   snapshotToContentState,
   visibleSchedulesToday,
 } from "../_shared/live_activity/event_snapshot.ts";
-import { sendLiveActivityToDevice } from "../_shared/live_activity/fcm_dispatch.ts";
 import type { TimetableCalendarRow } from "../_shared/live_activity/series_occurrences.ts";
 import {
   buildTimetableSnapshot,
@@ -25,7 +40,14 @@ import {
   emptyTimetableContentState,
   timetableSnapshotToContentState,
 } from "../_shared/live_activity/timetable_snapshot.ts";
-import type { CalendarEventRow, LiveActivityKind, ProfileRow, RequestBody, ScheduleRow } from "../_shared/live_activity/types.ts";
+import type {
+  CalendarEventRow,
+  DeviceRow,
+  LiveActivityKind,
+  ProfileRow,
+  RequestBody,
+  ScheduleRow,
+} from "../_shared/live_activity/types.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -50,6 +72,23 @@ function normalizeRequest(raw: RequestBody): RequestBody {
     kind: kind as LiveActivityKind,
     reference_id: referenceId,
   };
+}
+
+/** reference_id kann "YYYY-MM-DD" oder legacy "YYYY-MM-DD|klasse|track" sein. */
+function parseTimetableDayReference(referenceId: string): {
+  dayDate: string;
+  className?: string | null;
+  schooltrack?: string | null;
+} {
+  const parts = referenceId.split("|");
+  if (parts.length >= 3 && /^\d{4}-\d{2}-\d{2}$/.test(parts[0])) {
+    return {
+      dayDate: parts[0],
+      className: parts[1] || null,
+      schooltrack: parts[2] || null,
+    };
+  }
+  return { dayDate: referenceId.slice(0, 10) };
 }
 
 async function loadEvent(
@@ -149,12 +188,101 @@ function resolveFcmEvent(
   return resolveSegmentStartEvent(device);
 }
 
+function respondWithSummary(
+  summary: ReturnType<typeof createDispatchSummary>,
+): Response {
+  logDispatchSummary(summary);
+  return jsonResponse(summary);
+}
+
+async function buildTimetableTargets(
+  supabase: ReturnType<typeof createClient>,
+  devices: DeviceRow[],
+  dayDate: string,
+  action: LiveActivityFcmEvent,
+  now: Date,
+): Promise<{ targets: DispatchTarget[]; usersProcessed: number; skipped: DeviceDispatchDetail[] }> {
+  const grouped = groupDevicesByUser(devices);
+  const targets: DispatchTarget[] = [];
+  const skipped: DeviceDispatchDetail[] = [];
+  let usersProcessed = 0;
+
+  const snapshotCache = new Map<
+    string,
+    Record<string, string | number | boolean> | null
+  >();
+
+  for (const [, userDevices] of grouped) {
+    const profile = asProfile(userDevices[0]?.profiles);
+    if (!profile) {
+      for (const device of userDevices) {
+        skipped.push({
+          device_id: device.device_id,
+          user_id: device.user_id,
+          platform: device.platform,
+          result: "skipped",
+          skip_reason: "no_profile",
+        });
+      }
+      continue;
+    }
+
+    usersProcessed++;
+
+    const cacheKey = `${profile.class_name ?? ""}|${profile.schooltrack ?? ""}`;
+    let resolvedContentState = snapshotCache.get(cacheKey);
+
+    if (resolvedContentState === undefined) {
+      if (action === "end") {
+        resolvedContentState = emptyTimetableContentState(dayDate);
+      } else {
+        const rows = await loadMergedTimetableRows(supabase, dayDate, profile);
+        const snapshot = buildTimetableSnapshot(dayDate, rows, profile, now);
+        resolvedContentState = snapshot
+          ? timetableSnapshotToContentState(snapshot)
+          : null;
+      }
+      snapshotCache.set(cacheKey, resolvedContentState);
+    }
+
+    if (resolvedContentState === null) {
+      for (const device of userDevices) {
+        skipped.push({
+          device_id: device.device_id,
+          user_id: device.user_id,
+          platform: device.platform,
+          result: "skipped",
+          skip_reason: "no_snapshot",
+        });
+      }
+      continue;
+    }
+
+    for (const device of userDevices) {
+      const fcmEvent = resolveFcmEvent(device, action);
+      targets.push({
+        device,
+        fcmEvent,
+        contentState: resolvedContentState,
+        dedupKey: {
+          day_date: dayDate,
+          user_id: device.user_id,
+          device_id: device.device_id,
+        },
+      });
+    }
+  }
+
+  return { targets, usersProcessed, skipped };
+}
+
 async function handleEventDispatch(
   supabase: ReturnType<typeof createClient>,
   serviceAccount: ReturnType<typeof parseServiceAccountJson>,
   request: RequestBody,
   now: Date,
 ): Promise<Response> {
+  const startedAt = Date.now();
   const eventId = request.reference_id!;
   const action = request.action;
   if (!action || (action !== "start" && action !== "update" && action !== "end")) {
@@ -163,21 +291,34 @@ async function handleEventDispatch(
 
   const event = await loadEvent(supabase, eventId);
   if (!event || !isEventType(event.type)) {
-    return jsonResponse({ processed: 0, sent: 0, skipped: 0, mode: "dispatch", kind: "event" });
+    const summary = createDispatchSummary({
+      mode: "dispatch",
+      kind: "event",
+      reference_id: eventId,
+      action,
+      users_processed: 0,
+      devices_total: 0,
+      job_id: request.job_id ?? null,
+    }, startedAt, []);
+    return respondWithSummary(summary);
   }
 
   const schedules = await loadSchedules(supabase, eventId);
   const devices = await loadEventDevices(supabase, event);
   const scheduleId = request.schedule_id?.trim() || eventId;
-
-  let sent = 0;
-  let skipped = 0;
-  let failed = 0;
+  const targets: DispatchTarget[] = [];
+  const preSkipped: DeviceDispatchDetail[] = [];
 
   for (const device of devices) {
     const profile = asProfile(device.profiles);
     if (!profile) {
-      skipped++;
+      preSkipped.push({
+        device_id: device.device_id,
+        user_id: device.user_id,
+        platform: device.platform,
+        result: "skipped",
+        skip_reason: "no_profile",
+      });
       continue;
     }
 
@@ -187,7 +328,13 @@ async function handleEventDispatch(
     if (schedules.length === 0) {
       const snapshot = buildEventOnlySnapshot(event);
       if (!snapshot) {
-        skipped++;
+        preSkipped.push({
+          device_id: device.device_id,
+          user_id: device.user_id,
+          platform: device.platform,
+          result: "skipped",
+          skip_reason: "no_snapshot",
+        });
         continue;
       }
       contentState = snapshotToContentState(snapshot, eventId);
@@ -195,7 +342,13 @@ async function handleEventDispatch(
       const visible = visibleSchedulesToday(schedules, profile, filter, now);
       const snapshot = buildEventSnapshot(visible, now);
       if (!snapshot) {
-        skipped++;
+        preSkipped.push({
+          device_id: device.device_id,
+          user_id: device.user_id,
+          platform: device.platform,
+          result: "skipped",
+          skip_reason: "no_snapshot",
+        });
         continue;
       }
       contentState = snapshotToContentState(snapshot, eventId);
@@ -205,37 +358,37 @@ async function handleEventDispatch(
       ? resolveSegmentStartEvent(device)
       : action;
 
-    const result = await sendLiveActivityToDevice(supabase, serviceAccount, device, {
-      kind: "event",
-      referenceId: eventId,
+    targets.push({
+      device,
       fcmEvent,
       contentState,
-      activityType: "schedule_live_activity",
-      dedupTable: "schedule_live_activity_dispatches",
       dedupKey: {
         schedule_id: scheduleId,
         user_id: device.user_id,
         device_id: device.device_id,
       },
-      skipDedup: fcmEvent === "update",
     });
-
-    if (result === "sent") sent++;
-    else if (result === "failed") failed++;
-    else skipped++;
   }
 
-  return jsonResponse({
-    processed: 1,
-    sent,
-    failed,
-    skipped,
+  const sendDetails = await sendLiveActivityBatch(supabase, serviceAccount, targets, {
+    kind: "event",
+    referenceId: eventId,
+    activityType: "schedule_live_activity",
+    dedupTable: "schedule_live_activity_dispatches",
+    skipDedup: action === "update",
+  });
+
+  const summary = createDispatchSummary({
     mode: "dispatch",
     kind: "event",
     reference_id: eventId,
     action,
+    users_processed: new Set(devices.map((d) => d.user_id)).size,
+    devices_total: devices.length,
     job_id: request.job_id ?? null,
-  });
+  }, startedAt, [...preSkipped, ...sendDetails]);
+
+  return respondWithSummary(summary);
 }
 
 async function handleTimetableDispatch(
@@ -244,71 +397,71 @@ async function handleTimetableDispatch(
   request: RequestBody,
   now: Date,
 ): Promise<Response> {
-  const dayDate = request.reference_id!;
-  const userId = request.user_id;
+  const startedAt = Date.now();
+  const parsed = parseTimetableDayReference(request.reference_id!);
+  const dayDate = parsed.dayDate;
   const action = request.action;
 
-  if (!userId) {
-    return jsonResponse({ error: "user_id required for timetable dispatch" }, 400);
-  }
   if (!action || (action !== "start" && action !== "update" && action !== "end")) {
     return jsonResponse({ error: "action (start|update|end) required" }, 400);
   }
 
-  const profile = await loadProfile(supabase, userId);
-  if (!profile) {
-    return jsonResponse({ processed: 0, sent: 0, skipped: 0, mode: "dispatch", kind: "timetable" });
-  }
+  const className = request.class_name ?? parsed.className;
+  const schooltrack = request.schooltrack ?? parsed.schooltrack;
 
-  const rows = await loadMergedTimetableRows(supabase, dayDate, profile);
-  const snapshot = action === "end"
-    ? null
-    : buildTimetableSnapshot(dayDate, rows, profile, now);
+  const devices = await loadTimetableDevicesBulk(supabase, {
+    userId: request.user_id,
+    className: request.user_id ? undefined : className,
+    schooltrack: request.user_id ? undefined : schooltrack,
+  });
 
-  const contentState = snapshot
-    ? timetableSnapshotToContentState(snapshot)
-    : emptyTimetableContentState(dayDate);
-
-  const devices = await loadTimetableDevices(supabase, userId);
-  let sent = 0;
-  let skipped = 0;
-  let failed = 0;
-
-  for (const device of devices) {
-    const fcmEvent = resolveFcmEvent(device, action);
-    const result = await sendLiveActivityToDevice(supabase, serviceAccount, device, {
+  if (devices.length === 0) {
+    const summary = createDispatchSummary({
+      mode: "dispatch",
       kind: "timetable",
-      referenceId: dayDate,
-      fcmEvent,
-      contentState,
-      activityType: "timetable_live_activity",
-      dayDate,
-      dedupTable: "timetable_live_activity_dispatches",
-      dedupKey: {
-        day_date: dayDate,
-        user_id: device.user_id,
-        device_id: device.device_id,
-      },
-      skipDedup: fcmEvent === "update",
-    });
-
-    if (result === "sent") sent++;
-    else if (result === "failed") failed++;
-    else skipped++;
+      reference_id: dayDate,
+      action,
+      user_id: request.user_id ?? null,
+      class_name: className ?? null,
+      schooltrack: schooltrack ?? null,
+      users_processed: 0,
+      devices_total: 0,
+      job_id: request.job_id ?? null,
+    }, startedAt, []);
+    return respondWithSummary(summary);
   }
 
-  return jsonResponse({
-    processed: 1,
-    sent,
-    failed,
-    skipped,
+  const { targets, usersProcessed, skipped } = await buildTimetableTargets(
+    supabase,
+    devices,
+    dayDate,
+    action,
+    now,
+  );
+
+  const sendDetails = await sendLiveActivityBatch(supabase, serviceAccount, targets, {
+    kind: "timetable",
+    referenceId: dayDate,
+    activityType: "timetable_live_activity",
+    dayDate,
+    dedupTable: "timetable_live_activity_dispatches",
+    skipDedup: action === "update",
+  });
+
+  const summary = createDispatchSummary({
     mode: "dispatch",
     kind: "timetable",
     reference_id: dayDate,
-    user_id: userId,
     action,
+    user_id: request.user_id ?? null,
+    class_name: className ?? null,
+    schooltrack: schooltrack ?? null,
+    users_processed: usersProcessed,
+    devices_total: devices.length,
     job_id: request.job_id ?? null,
-  });
+  }, startedAt, [...skipped, ...sendDetails]);
+
+  return respondWithSummary(summary);
 }
 
 async function handleEventChange(
@@ -317,6 +470,7 @@ async function handleEventChange(
   request: RequestBody,
   now: Date,
 ): Promise<Response> {
+  const startedAt = Date.now();
   const eventId = request.reference_id!;
   const event = await loadEvent(
     supabase,
@@ -325,51 +479,70 @@ async function handleEventChange(
   );
 
   if (event && !isEventType(event.type)) {
-    return jsonResponse({ processed: 0, sent: 0, skipped: 0, mode: "change", kind: "event" });
+    const summary = createDispatchSummary({
+      mode: "change",
+      kind: "event",
+      reference_id: eventId,
+      users_processed: 0,
+      devices_total: 0,
+    }, startedAt, []);
+    return respondWithSummary(summary);
   }
 
   const schedules = await loadSchedules(supabase, eventId);
   const isDeleted = request.op === "DELETE" || event == null;
 
   if (!isDeleted && event && !isEventRelevantToday(event, schedules, now)) {
-    return jsonResponse({ processed: 1, sent: 0, skipped: 0, mode: "change", kind: "event" });
+    const summary = createDispatchSummary({
+      mode: "change",
+      kind: "event",
+      reference_id: eventId,
+      users_processed: 0,
+      devices_total: 0,
+    }, startedAt, []);
+    return respondWithSummary(summary);
   }
 
   const referenceEvent = event ?? request.event_snapshot;
   if (!referenceEvent) {
-    return jsonResponse({ processed: 1, sent: 0, skipped: 0, mode: "change", kind: "event" });
+    const summary = createDispatchSummary({
+      mode: "change",
+      kind: "event",
+      reference_id: eventId,
+      users_processed: 0,
+      devices_total: 0,
+    }, startedAt, []);
+    return respondWithSummary(summary);
   }
 
   const devices = await loadEventDevices(supabase, referenceEvent as CalendarEventRow);
-  let sent = 0;
-  let skipped = 0;
-  let failed = 0;
+  const targets: DispatchTarget[] = [];
+  const preSkipped: DeviceDispatchDetail[] = [];
 
   for (const device of devices) {
     const profile = asProfile(device.profiles);
     if (!profile) {
-      skipped++;
+      preSkipped.push({
+        device_id: device.device_id,
+        user_id: device.user_id,
+        platform: device.platform,
+        result: "skipped",
+        skip_reason: "no_profile",
+      });
       continue;
     }
 
     if (isDeleted || !event || !profileMatchesEvent(profile, referenceEvent as CalendarEventRow)) {
-      const result = await sendLiveActivityToDevice(supabase, serviceAccount, device, {
-        kind: "event",
-        referenceId: eventId,
+      targets.push({
+        device,
         fcmEvent: "end",
         contentState: emptyEventContentState(eventId),
-        activityType: "schedule_live_activity",
-        dedupTable: "schedule_live_activity_dispatches",
         dedupKey: {
           schedule_id: schedules.at(-1)?.id ?? eventId,
           user_id: device.user_id,
           device_id: device.device_id,
         },
-        skipDedup: true,
       });
-      if (result === "sent") sent++;
-      else if (result === "failed") failed++;
-      else skipped++;
       continue;
     }
 
@@ -379,7 +552,13 @@ async function handleEventChange(
     if (schedules.length === 0) {
       const snapshot = buildEventOnlySnapshot(event);
       if (!snapshot || !isEventActiveToday(event, now)) {
-        skipped++;
+        preSkipped.push({
+          device_id: device.device_id,
+          user_id: device.user_id,
+          platform: device.platform,
+          result: "skipped",
+          skip_reason: "no_snapshot",
+        });
         continue;
       }
       contentState = snapshotToContentState(snapshot, eventId);
@@ -387,20 +566,23 @@ async function handleEventChange(
       const visible = visibleSchedulesToday(schedules, profile, filter, now);
       const snapshot = buildEventSnapshot(visible, now);
       if (!snapshot) {
-        skipped++;
+        preSkipped.push({
+          device_id: device.device_id,
+          user_id: device.user_id,
+          platform: device.platform,
+          result: "skipped",
+          skip_reason: "no_snapshot",
+        });
         continue;
       }
       contentState = snapshotToContentState(snapshot, eventId);
     }
 
     const fcmEvent = resolveSegmentStartEvent(device);
-    const result = await sendLiveActivityToDevice(supabase, serviceAccount, device, {
-      kind: "event",
-      referenceId: eventId,
+    targets.push({
+      device,
       fcmEvent: fcmEvent === "start" ? "update" : fcmEvent,
       contentState,
-      activityType: "schedule_live_activity",
-      dedupTable: "schedule_live_activity_dispatches",
       dedupKey: {
         schedule_id: schedules.length > 0
           ? (buildEventSnapshot(visibleSchedulesToday(schedules, profile, filter, now), now)
@@ -409,23 +591,26 @@ async function handleEventChange(
         user_id: device.user_id,
         device_id: device.device_id,
       },
-      skipDedup: true,
     });
-
-    if (result === "sent") sent++;
-    else if (result === "failed") failed++;
-    else skipped++;
   }
 
-  return jsonResponse({
-    processed: 1,
-    sent,
-    failed,
-    skipped,
+  const sendDetails = await sendLiveActivityBatch(supabase, serviceAccount, targets, {
+    kind: "event",
+    referenceId: eventId,
+    activityType: "schedule_live_activity",
+    dedupTable: "schedule_live_activity_dispatches",
+    skipDedup: true,
+  });
+
+  const summary = createDispatchSummary({
     mode: "change",
     kind: "event",
     reference_id: eventId,
-  });
+    users_processed: new Set(devices.map((d) => d.user_id)).size,
+    devices_total: devices.length,
+  }, startedAt, [...preSkipped, ...sendDetails]);
+
+  return respondWithSummary(summary);
 }
 
 async function handleTimetableChange(
@@ -434,65 +619,52 @@ async function handleTimetableChange(
   request: RequestBody,
   now: Date,
 ): Promise<Response> {
+  const startedAt = Date.now();
   const dayDate = request.reference_id ?? new Intl.DateTimeFormat("en-CA", {
     timeZone: "Europe/Berlin",
   }).format(now);
 
-  const { data: userRows, error: userRowsError } = await supabase
-    .from("profile_push_devices")
-    .select("user_id")
-    .not("fcm_token", "is", null);
+  const devices = await loadTimetableDevicesBulk(supabase, {});
+  const { targets, usersProcessed, skipped } = await buildTimetableTargets(
+    supabase,
+    devices,
+    dayDate,
+    "update",
+    now,
+  );
 
-  if (userRowsError) throw new Error(userRowsError.message);
+  // Change-Events nutzen update/start je nach Gerätestatus.
+  const adjustedTargets = targets.map((target) => {
+    const fcmEvent = resolveSegmentStartEvent(target.device);
+    return {
+      ...target,
+      fcmEvent: fcmEvent === "start" ? "update" : fcmEvent,
+    };
+  });
 
-  const userIds = [...new Set((userRows ?? []).map((r) => r.user_id as string))];
+  const sendDetails = await sendLiveActivityBatch(
+    supabase,
+    serviceAccount,
+    adjustedTargets,
+    {
+      kind: "timetable",
+      referenceId: dayDate,
+      activityType: "timetable_live_activity",
+      dayDate,
+      dedupTable: "timetable_live_activity_dispatches",
+      skipDedup: true,
+    },
+  );
 
-  let sent = 0;
-  let skipped = 0;
-  let failed = 0;
-
-  for (const userId of userIds) {
-    const profile = await loadProfile(supabase, userId);
-    if (!profile) continue;
-
-    const rows = await loadMergedTimetableRows(supabase, dayDate, profile as ProfileRow);
-    const snapshot = buildTimetableSnapshot(dayDate, rows, profile as ProfileRow, now);
-    if (!snapshot) continue;
-
-    const devices = await loadTimetableDevices(supabase, userId);
-    for (const device of devices) {
-      const fcmEvent = resolveSegmentStartEvent(device);
-      const result = await sendLiveActivityToDevice(supabase, serviceAccount, device, {
-        kind: "timetable",
-        referenceId: dayDate,
-        fcmEvent: fcmEvent === "start" ? "update" : fcmEvent,
-        contentState: timetableSnapshotToContentState(snapshot),
-        activityType: "timetable_live_activity",
-        dayDate,
-        dedupTable: "timetable_live_activity_dispatches",
-        dedupKey: {
-          day_date: dayDate,
-          user_id: device.user_id,
-          device_id: device.device_id,
-        },
-        skipDedup: true,
-      });
-
-      if (result === "sent") sent++;
-      else if (result === "failed") failed++;
-      else skipped++;
-    }
-  }
-
-  return jsonResponse({
-    processed: 1,
-    sent,
-    failed,
-    skipped,
+  const summary = createDispatchSummary({
     mode: "change",
     kind: "timetable",
     reference_id: dayDate,
-  });
+    users_processed: usersProcessed,
+    devices_total: devices.length,
+  }, startedAt, [...skipped, ...sendDetails]);
+
+  return respondWithSummary(summary);
 }
 
 Deno.serve(async (req) => {
@@ -558,7 +730,11 @@ Deno.serve(async (req) => {
     return jsonResponse({ error: "Invalid mode" }, 400);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("live-activity unhandled", e);
+    console.error(JSON.stringify({
+      tag: "live_activity_dispatch",
+      error: "unhandled",
+      detail: message,
+    }));
     return jsonResponse({ error: "Unhandled error", detail: message }, 500);
   }
 });

--- a/supabase/migrations/20260709100000_timetable_bulk_dispatch.sql
+++ b/supabase/migrations/20260709100000_timetable_bulk_dispatch.sql
@@ -1,0 +1,340 @@
+-- Stundenplan-Dispatch: ein Cron-Job pro Kohorte (Klasse+Zweig) statt pro Nutzer.
+-- Edge Function verarbeitet alle Geräte der Kohorte in einem Aufruf (parallel).
+
+CREATE OR REPLACE FUNCTION public._schedule_live_activity_job(
+  p_kind text,
+  p_reference_id text,
+  p_user_id uuid,
+  p_schedule_id uuid,
+  p_action text,
+  p_run_at timestamptz,
+  p_class_name text DEFAULT NULL,
+  p_schooltrack text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, cron, vault
+AS $$
+DECLARE
+  v_job_id uuid;
+  v_jobname text;
+  v_cron_expr text;
+  v_secret text;
+  v_body jsonb;
+BEGIN
+  IF p_run_at <= now() THEN
+    RETURN;
+  END IF;
+
+  v_secret := public._live_activity_vault_secret();
+  IF v_secret IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_job_id := gen_random_uuid();
+  v_jobname := 'la-' || replace(v_job_id::text, '-', '');
+  v_cron_expr := public._timestamptz_to_cron_expr(p_run_at);
+
+  v_body := jsonb_build_object(
+    'mode', 'dispatch',
+    'kind', p_kind,
+    'reference_id', p_reference_id,
+    'action', p_action,
+    'job_id', v_job_id
+  );
+
+  IF p_user_id IS NOT NULL
+     AND p_user_id <> '00000000-0000-0000-0000-000000000000'::uuid THEN
+    v_body := v_body || jsonb_build_object('user_id', p_user_id);
+  END IF;
+
+  IF p_schedule_id IS NOT NULL
+     AND p_schedule_id <> '00000000-0000-0000-0000-000000000000'::uuid THEN
+    v_body := v_body || jsonb_build_object('schedule_id', p_schedule_id);
+  END IF;
+
+  IF p_class_name IS NOT NULL OR p_schooltrack IS NOT NULL THEN
+    v_body := v_body || jsonb_build_object(
+      'class_name', p_class_name,
+      'schooltrack', p_schooltrack
+    );
+  END IF;
+
+  BEGIN
+    INSERT INTO public.live_activity_jobs (
+      id, kind, reference_id, user_id, schedule_id, action, run_at, cron_jobname
+    ) VALUES (
+      v_job_id,
+      p_kind,
+      p_reference_id,
+      coalesce(p_user_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      coalesce(p_schedule_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      p_action,
+      p_run_at,
+      v_jobname
+    );
+  EXCEPTION
+    WHEN unique_violation THEN
+      RETURN;
+  END;
+
+  PERFORM cron.schedule(
+    v_jobname,
+    v_cron_expr,
+    format(
+      $job$
+      SELECT net.http_post(
+        url := 'https://chrbvfaknykaycwumuba.supabase.co/functions/v1/live-activity',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'x-cron-secret', %L
+        ),
+        body := %L::jsonb
+      );
+      SELECT cron.unschedule(%L);
+      DELETE FROM public.live_activity_jobs WHERE id = %L::uuid;
+      $job$,
+      v_secret,
+      v_body::text,
+      v_jobname,
+      v_job_id
+    )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public._timetable_cohort_reference_id(
+  p_day_date date,
+  p_class_name text,
+  p_schooltrack text
+)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT to_char(p_day_date, 'YYYY-MM-DD')
+    || '|' || coalesce(p_class_name, '')
+    || '|' || coalesce(p_schooltrack, '');
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_timetable_cohort_live_activity_jobs(
+  p_class_name text,
+  p_schooltrack text,
+  p_day_date date
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile record;
+  v_day_key text;
+  v_ref_key text;
+  v_bounds_start timestamptz;
+  v_bounds_end timestamptz;
+  v_segment record;
+  v_segments_count int := 0;
+  v_first_start timestamptz;
+  v_activity_start timestamptz;
+  v_last_end timestamptz;
+  v_is_first boolean := true;
+  v_prev_end timestamptz;
+BEGIN
+  v_day_key := to_char(p_day_date, 'YYYY-MM-DD');
+  v_ref_key := public._timetable_cohort_reference_id(p_day_date, p_class_name, p_schooltrack);
+
+  PERFORM public._clear_live_activity_jobs('timetable', v_ref_key, NULL);
+
+  SELECT id, class_name, schooltrack
+  INTO v_profile
+  FROM public.profiles p
+  WHERE p.class_name IS NOT DISTINCT FROM p_class_name
+    AND p.schooltrack::text IS NOT DISTINCT FROM p_schooltrack
+    AND EXISTS (
+      SELECT 1
+      FROM public.profile_push_devices d
+      WHERE d.user_id = p.id
+        AND d.fcm_token IS NOT NULL
+    )
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  v_bounds_start := (p_day_date::text || 'T00:00:00')::timestamptz AT TIME ZONE 'Europe/Berlin';
+  v_bounds_end := (p_day_date::text || 'T23:59:59')::timestamptz AT TIME ZONE 'Europe/Berlin';
+
+  CREATE TEMP TABLE IF NOT EXISTS _la_timetable_segments (
+    id uuid,
+    seg_type text,
+    start_time timestamptz,
+    end_time timestamptz
+  ) ON COMMIT DROP;
+
+  TRUNCATE _la_timetable_segments;
+
+  INSERT INTO _la_timetable_segments (id, seg_type, start_time, end_time)
+  SELECT
+    ce.id,
+    ce.type::text,
+    ce.start_time,
+    coalesce(ce.end_time, ce.start_time + interval '45 minutes')
+  FROM public.calendar_events ce
+  WHERE ce.type IN ('lesson', 'meal')
+    AND ce.start_time >= v_bounds_start
+    AND ce.start_time <= v_bounds_end
+    AND (
+      ce.type = 'lesson'
+      OR public._is_lunch_meal(ce.start_time)
+    )
+    AND public._lesson_matches_profile(
+      ce.class::text,
+      ce.schooltrack::text,
+      v_profile.class_name,
+      v_profile.schooltrack::text
+    )
+  ORDER BY ce.start_time ASC;
+
+  SELECT count(*) INTO v_segments_count FROM _la_timetable_segments;
+  IF v_segments_count = 0 THEN
+    RETURN;
+  END IF;
+
+  SELECT min(start_time) INTO v_first_start FROM _la_timetable_segments;
+  v_activity_start := v_first_start - interval '15 minutes';
+
+  IF v_activity_start > now() THEN
+    PERFORM public._schedule_live_activity_job(
+      'timetable', v_ref_key, NULL, NULL, 'start', v_activity_start,
+      p_class_name, p_schooltrack
+    );
+  END IF;
+
+  v_prev_end := NULL;
+  FOR v_segment IN
+    SELECT id, seg_type, start_time, end_time
+    FROM _la_timetable_segments
+    ORDER BY start_time ASC
+  LOOP
+    IF v_prev_end IS NOT NULL AND v_prev_end > now() THEN
+      PERFORM public._schedule_live_activity_job(
+        'timetable', v_ref_key, NULL, v_segment.id, 'update', v_prev_end,
+        p_class_name, p_schooltrack
+      );
+    END IF;
+
+    IF NOT v_is_first AND v_segment.start_time > now() THEN
+      PERFORM public._schedule_live_activity_job(
+        'timetable', v_ref_key, NULL, v_segment.id, 'update', v_segment.start_time,
+        p_class_name, p_schooltrack
+      );
+    END IF;
+
+    v_last_end := v_segment.end_time;
+    v_prev_end := v_segment.end_time;
+    v_is_first := false;
+  END LOOP;
+
+  IF v_last_end IS NOT NULL AND v_last_end > now() THEN
+    PERFORM public._schedule_live_activity_job(
+      'timetable', v_ref_key, NULL, NULL, 'end', v_last_end,
+      p_class_name, p_schooltrack
+    );
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_timetable_live_activity_jobs(
+  p_user_id uuid,
+  p_day_date date
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile record;
+BEGIN
+  SELECT class_name, schooltrack::text
+  INTO v_profile
+  FROM public.profiles
+  WHERE id = p_user_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  PERFORM public.sync_timetable_cohort_live_activity_jobs(
+    v_profile.class_name,
+    v_profile.schooltrack,
+    p_day_date
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_all_timetable_jobs_for_day(p_day_date date)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  r record;
+BEGIN
+  IF p_day_date < current_date OR p_day_date > current_date + 14 THEN
+    RETURN;
+  END IF;
+
+  FOR r IN
+    SELECT DISTINCT p.class_name, p.schooltrack::text AS schooltrack
+    FROM public.profiles p
+    WHERE EXISTS (
+      SELECT 1
+      FROM public.profile_push_devices d
+      WHERE d.user_id = p.id
+        AND d.fcm_token IS NOT NULL
+    )
+  LOOP
+    PERFORM public.sync_timetable_cohort_live_activity_jobs(
+      r.class_name,
+      r.schooltrack,
+      p_day_date
+    );
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sync_timetable_cohort_live_activity_jobs(text, text, date) IS
+  'Plant Stundenplan-Live-Activity-Jobs pro Kohorte (Klasse+Zweig), nicht pro Nutzer.';
+
+-- Alte per-Nutzer-Stundenplan-Jobs entfernen (reference_id ohne "|" und user_id gesetzt).
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT cron_jobname
+    FROM public.live_activity_jobs
+    WHERE kind = 'timetable'
+      AND reference_id NOT LIKE '%|%'
+      AND user_id <> '00000000-0000-0000-0000-000000000000'::uuid
+  LOOP
+    BEGIN
+      PERFORM cron.unschedule(r.cron_jobname);
+    EXCEPTION
+      WHEN OTHERS THEN NULL;
+    END;
+  END LOOP;
+
+  DELETE FROM public.live_activity_jobs
+  WHERE kind = 'timetable'
+    AND reference_id NOT LIKE '%|%'
+    AND user_id <> '00000000-0000-0000-0000-000000000000'::uuid;
+END $$;
+
+-- Kohorten-Jobs neu planen.
+SELECT public.sync_timetable_jobs_horizon();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

- **Bulk-Dispatch** für Stundenplan-Live-Activities pro Kohorte (Klasse+Zweig) statt pro User
- **Strukturiertes Dispatch-Logging** (`sent`, `skipped`, `failed`, `skip_reasons`)
- **Parallele FCM-Sends** mit Batch-Dedup
- **Cron-Jobs** pro Kohorte (~56 statt ~2208 Jobs)
- **Bug-Fix**: `action=start` wird nicht mehr fälschlich zu `update` umgeleitet
- **iOS ContentState-Fix**: Widget liest Remote-Push-Daten aus `context.state` (APNS `content-state`), UserDefaults nur noch als Fallback für lokal gestartete Activities

## Problem (iOS Remote Push-to-Start)

Bei serverseitigem Start-Push kannte Flutter die neue Activity-UUID noch nicht und schrieb keine UserDefaults. Das Widget hatte ein leeres `ContentState` und zeigte nichts an – obwohl FCM `sent: 1` meldete.

## Lösung

`ContentState` in der Widget Extension enthält jetzt alle Felder aus dem Server-Payload (`kind`, `currentTitle`, `segmentsJson`, `segmentStartMs`, …). `TimetableLiveData`, `ScheduleLiveData` und `readKind` lesen primär aus `context.state`.

## Wichtig für Tests

Dieser Fix erfordert einen **neuen iOS-App-Build** (nicht nur Edge-Function-Deploy). Nach Installation auf dem iPad erneut Start-Push testen.

## Betroffene Dateien

- `supabase/functions/live-activity/` – Bulk-Dispatch, Logging
- `supabase/functions/_shared/live_activity/` – FCM-Batch, Devices, Snapshots
- `supabase/migrations/20260709100000_timetable_bulk_dispatch.sql` – Kohorten-Cron
- `ios/ChronoWidgetExtension/ChronoWidgetExtensionLiveActivity.swift` – ContentState-Fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20a8d8e7-9905-41ae-9e48-83918f68fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20a8d8e7-9905-41ae-9e48-83918f68fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

